### PR TITLE
refactor(tests): replace class-based tests with plain functions

### DIFF
--- a/src/tests/accounts/test_forms.py
+++ b/src/tests/accounts/test_forms.py
@@ -5,66 +5,63 @@ Tests for accounts.forms module.
 from accounts.forms import CustomPasswordChangeForm, UserProfileForm
 
 
-class TestUserProfileForm:
-    """Tests for the UserProfileForm."""
+def test_user_profile_form_has_expected_fields():
+    """The form contains the expected fields."""
+    form = UserProfileForm()
 
-    def test_form_has_expected_fields(self):
-        """The form contains the expected fields."""
-        form = UserProfileForm()
-
-        assert "username" in form.fields
-        assert "email" in form.fields
-        assert "first_name" in form.fields
-        assert "last_name" in form.fields
-        # Password should NOT be in this form
-        assert "password" not in form.fields
-
-    def test_form_widgets_have_daisyui_classes(self):
-        """Form widgets have the expected DaisyUI styling classes."""
-        form = UserProfileForm()
-
-        for field_name in form.fields:
-            widget_class = form.fields[field_name].widget.attrs.get("class", "")
-            assert "input" in widget_class
-            assert "validator" in widget_class
-            assert "w-full" in widget_class
-
-    def test_form_widgets_have_htmx_validation_attrs(self):
-        """Form widgets have the expected HTMX validation attributes."""
-        form = UserProfileForm()
-
-        for field_name in form.fields:
-            widget_attrs = form.fields[field_name].widget.attrs
-            assert "hx-post" in widget_attrs
-            assert "hx-trigger" in widget_attrs
-            assert widget_attrs["hx-trigger"] == "input changed delay:500ms"
-            assert widget_attrs["hx-target"] == f"#error-{field_name}"
-            assert widget_attrs["hx-include"] == f"[name='{field_name}']"
-            assert "hx-vals" in widget_attrs
+    assert "username" in form.fields
+    assert "email" in form.fields
+    assert "first_name" in form.fields
+    assert "last_name" in form.fields
+    # Password should NOT be in this form
+    assert "password" not in form.fields
 
 
-class TestCustomPasswordChangeForm:
-    """Tests for the CustomPasswordChangeForm."""
+def test_user_profile_form_widgets_have_daisyui_classes():
+    """Form widgets have the expected DaisyUI styling classes."""
+    form = UserProfileForm()
 
-    def test_form_widgets_have_daisyui_classes(self, user):
-        """Form widgets have the expected DaisyUI styling classes."""
-        form = CustomPasswordChangeForm(user)
+    for field_name in form.fields:
+        widget_class = form.fields[field_name].widget.attrs.get("class", "")
+        assert "input" in widget_class
+        assert "validator" in widget_class
+        assert "w-full" in widget_class
 
-        for field_name in form.fields:
-            widget_class = form.fields[field_name].widget.attrs.get("class", "")
-            assert "input" in widget_class
-            assert "validator" in widget_class
-            assert "w-full" in widget_class
 
-    def test_form_widgets_have_htmx_validation_attrs(self, user):
-        """Form widgets have the expected HTMX validation attributes."""
-        form = CustomPasswordChangeForm(user)
+def test_user_profile_form_widgets_have_htmx_validation_attrs():
+    """Form widgets have the expected HTMX validation attributes."""
+    form = UserProfileForm()
 
-        for field_name in form.fields:
-            widget_attrs = form.fields[field_name].widget.attrs
-            assert "hx-post" in widget_attrs
-            assert "hx-trigger" in widget_attrs
-            assert widget_attrs["hx-trigger"] == "input changed delay:500ms"
-            assert widget_attrs["hx-target"] == f"#error-{field_name}"
-            assert "hx-include" in widget_attrs
-            assert "hx-vals" in widget_attrs
+    for field_name in form.fields:
+        widget_attrs = form.fields[field_name].widget.attrs
+        assert "hx-post" in widget_attrs
+        assert "hx-trigger" in widget_attrs
+        assert widget_attrs["hx-trigger"] == "input changed delay:500ms"
+        assert widget_attrs["hx-target"] == f"#error-{field_name}"
+        assert widget_attrs["hx-include"] == f"[name='{field_name}']"
+        assert "hx-vals" in widget_attrs
+
+
+def test_password_change_form_widgets_have_daisyui_classes(user):
+    """Form widgets have the expected DaisyUI styling classes."""
+    form = CustomPasswordChangeForm(user)
+
+    for field_name in form.fields:
+        widget_class = form.fields[field_name].widget.attrs.get("class", "")
+        assert "input" in widget_class
+        assert "validator" in widget_class
+        assert "w-full" in widget_class
+
+
+def test_password_change_form_widgets_have_htmx_validation_attrs(user):
+    """Form widgets have the expected HTMX validation attributes."""
+    form = CustomPasswordChangeForm(user)
+
+    for field_name in form.fields:
+        widget_attrs = form.fields[field_name].widget.attrs
+        assert "hx-post" in widget_attrs
+        assert "hx-trigger" in widget_attrs
+        assert widget_attrs["hx-trigger"] == "input changed delay:500ms"
+        assert widget_attrs["hx-target"] == f"#error-{field_name}"
+        assert "hx-include" in widget_attrs
+        assert "hx-vals" in widget_attrs

--- a/src/tests/accounts/test_views.py
+++ b/src/tests/accounts/test_views.py
@@ -9,112 +9,111 @@ from django.contrib.messages import get_messages
 from django.urls import reverse
 
 
-class TestProfileEditView:
-    """Tests for the profile_edit view."""
+def test_profile_edit_accessible_when_logged_in(logged_in_client):
+    """The profile edit view is accessible when logged in."""
+    response = logged_in_client.get(reverse("accounts:profile_edit"))
 
-    def test_profile_edit_accessible_when_logged_in(self, logged_in_client):
-        """The profile edit view is accessible when logged in."""
-        response = logged_in_client.get(reverse("accounts:profile_edit"))
-
-        assert response.status_code == 200
-
-    def test_profile_edit_displays_both_forms(self, logged_in_client):
-        """The view displays both profile and password forms."""
-        response = logged_in_client.get(reverse("accounts:profile_edit"))
-
-        assert response.status_code == 200
-        assert "profile_form" in response.context
-        assert "password_form" in response.context
-
-    def test_profile_edit_prefills_user_data(self, logged_in_client, user):
-        """The profile form is prefilled with current user data."""
-        response = logged_in_client.get(reverse("accounts:profile_edit"))
-
-        assert response.context["profile_form"].initial["username"] == user.username
-        assert response.context["profile_form"].initial["email"] == user.email
-
-    def test_update_profile_success(self, logged_in_client, user):
-        """Submitting valid profile data updates the user."""
-        url = reverse("accounts:profile_edit")
-        data = {
-            "username": "newusername",
-            "email": "newemail@example.com",
-            "first_name": "New",
-            "last_name": "Name",
-            "update_profile": "",  # Indicates which form was submitted
-        }
-
-        response = logged_in_client.post(url, data)
-
-        assert response.status_code == 302  # Redirect after success
-        user.refresh_from_db()
-        assert user.username == "newusername"
-        assert user.email == "newemail@example.com"
-        assert user.first_name == "New"
-        assert user.last_name == "Name"
-
-    def test_change_password_success(self, logged_in_client, user):
-        """Submitting valid password data changes the password."""
-        url = reverse("accounts:profile_edit")
-        data = {
-            "old_password": "testpass123",
-            "new_password1": "newSecurePass456!",
-            "new_password2": "newSecurePass456!",
-            "change_password": "",  # Indicates which form was submitted
-        }
-
-        response = logged_in_client.post(url, data)
-
-        assert response.status_code == 302  # Redirect after success
-        user.refresh_from_db()
-        assert user.check_password("newSecurePass456!")
-
-        response = logged_in_client.post(url, data)
-
-        assert response.status_code == 200  # Form re-displayed with errors
-        assert response.context["password_form"].errors
+    assert response.status_code == 200
 
 
-class TestSetLanguageView:
-    """Tests for the set_language_view."""
+def test_profile_edit_displays_both_forms(logged_in_client):
+    """The view displays both profile and password forms."""
+    response = logged_in_client.get(reverse("accounts:profile_edit"))
 
-    def test_set_language_changes_language(self, logged_in_client):
-        """POST with valid language code changes the language."""
-        response = logged_in_client.post(
-            reverse("accounts:set_language"),
-            {"language": "fr"},
-        )
+    assert response.status_code == 200
+    assert "profile_form" in response.context
+    assert "password_form" in response.context
 
-        # Should redirect (default behavior of set_language)
-        assert response.status_code == 302
 
-    def test_set_language_shows_success_message(self, logged_in_client):
-        """Setting language shows a success message."""
+def test_profile_edit_prefills_user_data(logged_in_client, user):
+    """The profile form is prefilled with current user data."""
+    response = logged_in_client.get(reverse("accounts:profile_edit"))
 
-        response = logged_in_client.post(
-            reverse("accounts:set_language"),
-            {"language": "fr"},
-            follow=True,
-        )
+    assert response.context["profile_form"].initial["username"] == user.username
+    assert response.context["profile_form"].initial["email"] == user.email
 
-        messages = list(get_messages(response.wsgi_request))
-        assert any(("lang" in str(m).lower()) for m in messages)
 
-    def test_set_language_ignores_invalid_language(self, logged_in_client):
-        """Invalid language codes don't show success message."""
+def test_update_profile_success(logged_in_client, user):
+    """Submitting valid profile data updates the user."""
+    url = reverse("accounts:profile_edit")
+    data = {
+        "username": "newusername",
+        "email": "newemail@example.com",
+        "first_name": "New",
+        "last_name": "Name",
+        "update_profile": "",  # Indicates which form was submitted
+    }
 
-        response = logged_in_client.post(
-            reverse("accounts:set_language"),
-            {"language": "invalid"},
-            follow=True,
-        )
+    response = logged_in_client.post(url, data)
 
-        messages = list(get_messages(response.wsgi_request))
-        assert not any(("lang" in str(m).lower()) for m in messages)
+    assert response.status_code == 302  # Redirect after success
+    user.refresh_from_db()
+    assert user.username == "newusername"
+    assert user.email == "newemail@example.com"
+    assert user.first_name == "New"
+    assert user.last_name == "Name"
 
-    def test_set_language_get_not_allowed(self, logged_in_client):
-        """GET request is not allowed (require_POST decorator)."""
-        response = logged_in_client.get(reverse("accounts:set_language"))
 
-        # require_POST returns 405 Method Not Allowed for GET
-        assert response.status_code == 405
+def test_change_password_success(logged_in_client, user):
+    """Submitting valid password data changes the password."""
+    url = reverse("accounts:profile_edit")
+    data = {
+        "old_password": "testpass123",
+        "new_password1": "newSecurePass456!",
+        "new_password2": "newSecurePass456!",
+        "change_password": "",  # Indicates which form was submitted
+    }
+
+    response = logged_in_client.post(url, data)
+
+    assert response.status_code == 302  # Redirect after success
+    user.refresh_from_db()
+    assert user.check_password("newSecurePass456!")
+
+    response = logged_in_client.post(url, data)
+
+    assert response.status_code == 200  # Form re-displayed with errors
+    assert response.context["password_form"].errors
+
+
+def test_set_language_changes_language(logged_in_client):
+    """POST with valid language code changes the language."""
+    response = logged_in_client.post(
+        reverse("accounts:set_language"),
+        {"language": "fr"},
+    )
+
+    # Should redirect (default behavior of set_language)
+    assert response.status_code == 302
+
+
+def test_set_language_shows_success_message(logged_in_client):
+    """Setting language shows a success message."""
+    response = logged_in_client.post(
+        reverse("accounts:set_language"),
+        {"language": "fr"},
+        follow=True,
+    )
+
+    messages = list(get_messages(response.wsgi_request))
+    assert any(("lang" in str(m).lower()) for m in messages)
+
+
+def test_set_language_ignores_invalid_language(logged_in_client):
+    """Invalid language codes don't show success message."""
+    response = logged_in_client.post(
+        reverse("accounts:set_language"),
+        {"language": "invalid"},
+        follow=True,
+    )
+
+    messages = list(get_messages(response.wsgi_request))
+    assert not any(("lang" in str(m).lower()) for m in messages)
+
+
+def test_set_language_get_not_allowed(logged_in_client):
+    """GET request is not allowed (require_POST decorator)."""
+    response = logged_in_client.get(reverse("accounts:set_language"))
+
+    # require_POST returns 405 Method Not Allowed for GET
+    assert response.status_code == 405

--- a/src/tests/core/test_context_processors.py
+++ b/src/tests/core/test_context_processors.py
@@ -6,79 +6,74 @@ These tests verify the behavior of context processors.
 
 from django.contrib.auth.models import AnonymousUser
 from django.test import RequestFactory
+from django.urls import reverse
 
 from core.context_processors import saved_views
 from core.models import SavedView
 
 
-class TestSavedViewsContextProcessor:
-    """Tests for the saved_views context processor."""
+def test_authenticated_user_gets_their_saved_views(user, db):
+    """Authenticated users receive their saved views in context."""
+    SavedView.objects.create(user=user, name="View 1")
+    SavedView.objects.create(user=user, name="View 2")
 
-    def test_authenticated_user_gets_their_saved_views(self, user, db):
-        """Authenticated users receive their saved views in context."""
-        # Create saved views for the user
-        SavedView.objects.create(user=user, name="View 1")
-        SavedView.objects.create(user=user, name="View 2")
+    factory = RequestFactory()
+    request = factory.get("/")
+    request.user = user
 
-        # Create a mock request with the authenticated user
-        factory = RequestFactory()
-        request = factory.get("/")
-        request.user = user
+    result = saved_views(request)
 
-        result = saved_views(request)
+    assert "saved_views" in result
+    assert result["saved_views"].count() == 2
 
-        assert "saved_views" in result
-        assert result["saved_views"].count() == 2
 
-    def test_authenticated_user_only_gets_own_views(self, user, django_user_model, db):
-        """Users only receive their own saved views, not others'."""
-        # Create another user with saved views
-        other_user = django_user_model.objects.create_user(
-            username="otheruser",
-            email="other@example.com",
-            password="testpass123",
-        )
-        SavedView.objects.create(user=other_user, name="Other View")
-        SavedView.objects.create(user=user, name="My View")
+def test_authenticated_user_only_gets_own_views(user, django_user_model, db):
+    """Users only receive their own saved views, not others'."""
+    other_user = django_user_model.objects.create_user(
+        username="otheruser",
+        email="other@example.com",
+        password="testpass123",
+    )
+    SavedView.objects.create(user=other_user, name="Other View")
+    SavedView.objects.create(user=user, name="My View")
 
-        factory = RequestFactory()
-        request = factory.get("/")
-        request.user = user
+    factory = RequestFactory()
+    request = factory.get("/")
+    request.user = user
 
-        result = saved_views(request)
+    result = saved_views(request)
 
-        assert result["saved_views"].count() == 1
-        assert result["saved_views"].first().name == "My View"
+    assert result["saved_views"].count() == 1
+    assert result["saved_views"].first().name == "My View"
 
-    def test_anonymous_user_gets_empty_queryset(self, db):
-        """Anonymous users receive an empty queryset."""
 
-        factory = RequestFactory()
-        request = factory.get("/")
-        request.user = AnonymousUser()
+def test_anonymous_user_gets_empty_queryset(db):
+    """Anonymous users receive an empty queryset."""
+    factory = RequestFactory()
+    request = factory.get("/")
+    request.user = AnonymousUser()
 
-        result = saved_views(request)
+    result = saved_views(request)
 
-        assert "saved_views" in result
-        assert result["saved_views"].count() == 0
+    assert "saved_views" in result
+    assert result["saved_views"].count() == 0
 
-    def test_saved_views_available_on_all_pages(self, logged_in_client, user, db):
-        """Saved views are available in context on various pages."""
-        from django.urls import reverse
 
-        SavedView.objects.create(user=user, name="Test View")
+def test_saved_views_available_on_all_pages(logged_in_client, user, db):
+    """Saved views are available in context on various pages."""
+    SavedView.objects.create(user=user, name="Test View")
 
-        # Test home page
-        response = logged_in_client.get(reverse("home"))
-        assert "saved_views" in response.context
-        assert response.context["saved_views"].count() == 1
+    # Test home page
+    response = logged_in_client.get(reverse("home"))
+    assert "saved_views" in response.context
+    assert response.context["saved_views"].count() == 1
 
-        # Test import page
-        response = logged_in_client.get(reverse("media_import"))
-        assert "saved_views" in response.context
-        assert response.context["saved_views"].count() == 1
+    # Test import page
+    response = logged_in_client.get(reverse("media_import"))
+    assert "saved_views" in response.context
+    assert response.context["saved_views"].count() == 1
 
-        # Test backup manage page
-        response = logged_in_client.get(reverse("backup_manage"))
-        assert "saved_views" in response.context
-        assert response.context["saved_views"].count() == 1
+    # Test backup manage page
+    response = logged_in_client.get(reverse("backup_manage"))
+    assert "saved_views" in response.context
+    assert response.context["saved_views"].count() == 1

--- a/src/tests/core/test_forms.py
+++ b/src/tests/core/test_forms.py
@@ -8,136 +8,142 @@ from core.forms import MediaForm
 from core.models import Agent, Media
 
 
-class TestMediaForm:
-    """Tests for the MediaForm."""
+def test_form_valid_with_required_fields(db):
+    """Form is valid with only required fields."""
+    data = {
+        "title": "Test Book",
+        "media_type": "BOOK",
+        "status": "PLANNED",
+    }
+    form = MediaForm(data=data)
 
-    def test_form_valid_with_required_fields(self, db):
-        """Form is valid with only required fields."""
+    assert form.is_valid(), form.errors
+
+
+def test_form_invalid_without_title(db):
+    """Form is invalid without a title."""
+    data = {
+        "media_type": "BOOK",
+        "status": "PLANNED",
+    }
+    form = MediaForm(data=data)
+
+    assert not form.is_valid()
+    assert "title" in form.errors
+
+
+def test_form_invalid_without_media_type(db):
+    """Form is invalid without a media type."""
+    data = {
+        "title": "Test",
+        "status": "PLANNED",
+    }
+    form = MediaForm(data=data)
+
+    assert not form.is_valid()
+    assert "media_type" in form.errors
+
+
+def test_form_accepts_valid_pub_year(db):
+    """Form accepts a valid publication year."""
+    data = {
+        "title": "Test",
+        "media_type": "BOOK",
+        "status": "PLANNED",
+        "pub_year": 2024,
+    }
+    form = MediaForm(data=data)
+
+    assert form.is_valid(), form.errors
+
+
+def test_form_rejects_invalid_pub_year(db):
+    """Form rejects a publication year outside valid range."""
+    data = {
+        "title": "Test",
+        "media_type": "BOOK",
+        "status": "PLANNED",
+        "pub_year": -5000,
+    }
+    form = MediaForm(data=data)
+
+    assert not form.is_valid()
+    assert "pub_year" in form.errors
+
+
+def test_form_saves_with_contributors(db):
+    """Form can save a media with existing contributors."""
+    agent = Agent.objects.create(name="Author")
+    data = {
+        "title": "Test",
+        "media_type": "BOOK",
+        "status": "PLANNED",
+        "contributors": [agent.pk],
+    }
+    form = MediaForm(data=data)
+
+    assert form.is_valid(), form.errors
+    media = form.save()
+    assert agent in media.contributors.all()
+
+
+def test_form_updates_existing_media(db):
+    """Form can update an existing media instance."""
+    media = Media.objects.create(
+        title="Original",
+        media_type="BOOK",
+        status="PLANNED",
+    )
+    data = {
+        "title": "Updated",
+        "media_type": "FILM",
+        "status": "COMPLETED",
+    }
+    form = MediaForm(data=data, instance=media)
+
+    assert form.is_valid(), form.errors
+    updated = form.save()
+    assert updated.pk == media.pk
+    assert updated.title == "Updated"
+    assert updated.media_type == "FILM"
+
+
+def test_form_accepts_all_media_types(db):
+    """Form accepts all valid media types."""
+    valid_types = ["BOOK", "GAME", "MUSIC", "COMIC", "FILM", "TV", "PERF", "BROADCAST"]
+
+    for media_type in valid_types:
         data = {
-            "title": "Test Book",
+            "title": f"Test {media_type}",
+            "media_type": media_type,
+            "status": "PLANNED",
+        }
+        form = MediaForm(data=data)
+        assert form.is_valid(), f"Failed for {media_type}: {form.errors}"
+
+
+def test_form_accepts_all_statuses(db):
+    """Form accepts all valid statuses."""
+    valid_statuses = ["PLANNED", "IN_PROGRESS", "COMPLETED", "PAUSED", "DNF"]
+
+    for status in valid_statuses:
+        data = {
+            "title": f"Test {status}",
             "media_type": "BOOK",
-            "status": "PLANNED",
+            "status": status,
         }
         form = MediaForm(data=data)
+        assert form.is_valid(), f"Failed for {status}: {form.errors}"
 
-        assert form.is_valid(), form.errors
 
-    def test_form_invalid_without_title(self, db):
-        """Form is invalid without a title."""
+def test_form_accepts_all_scores(db):
+    """Form accepts all valid scores."""
+    for score in range(1, 11):
         data = {
+            "title": f"Test score {score}",
             "media_type": "BOOK",
-            "status": "PLANNED",
-        }
-        form = MediaForm(data=data)
-
-        assert not form.is_valid()
-        assert "title" in form.errors
-
-    def test_form_invalid_without_media_type(self, db):
-        """Form is invalid without a media type."""
-        data = {
-            "title": "Test",
-            "status": "PLANNED",
-        }
-        form = MediaForm(data=data)
-
-        assert not form.is_valid()
-        assert "media_type" in form.errors
-
-    def test_form_accepts_valid_pub_year(self, db):
-        """Form accepts a valid publication year."""
-        data = {
-            "title": "Test",
-            "media_type": "BOOK",
-            "status": "PLANNED",
-            "pub_year": 2024,
-        }
-        form = MediaForm(data=data)
-
-        assert form.is_valid(), form.errors
-
-    def test_form_rejects_invalid_pub_year(self, db):
-        """Form rejects a publication year outside valid range."""
-        data = {
-            "title": "Test",
-            "media_type": "BOOK",
-            "status": "PLANNED",
-            "pub_year": -5000,
-        }
-        form = MediaForm(data=data)
-
-        assert not form.is_valid()
-        assert "pub_year" in form.errors
-
-    def test_form_saves_with_contributors(self, db):
-        """Form can save a media with existing contributors."""
-        agent = Agent.objects.create(name="Author")
-        data = {
-            "title": "Test",
-            "media_type": "BOOK",
-            "status": "PLANNED",
-            "contributors": [agent.pk],
-        }
-        form = MediaForm(data=data)
-
-        assert form.is_valid(), form.errors
-        media = form.save()
-        assert agent in media.contributors.all()
-
-    def test_form_updates_existing_media(self, db):
-        """Form can update an existing media instance."""
-        media = Media.objects.create(
-            title="Original",
-            media_type="BOOK",
-            status="PLANNED",
-        )
-        data = {
-            "title": "Updated",
-            "media_type": "FILM",
             "status": "COMPLETED",
+            "score": score,
         }
-        form = MediaForm(data=data, instance=media)
-
-        assert form.is_valid(), form.errors
-        updated = form.save()
-        assert updated.pk == media.pk
-        assert updated.title == "Updated"
-        assert updated.media_type == "FILM"
-
-    def test_form_accepts_all_media_types(self, db):
-        """Form accepts all valid media types."""
-        valid_types = ["BOOK", "GAME", "MUSIC", "COMIC", "FILM", "TV", "PERF", "BROADCAST"]
-
-        for media_type in valid_types:
-            data = {
-                "title": f"Test {media_type}",
-                "media_type": media_type,
-                "status": "PLANNED",
-            }
-            form = MediaForm(data=data)
-            assert form.is_valid(), f"Failed for {media_type}: {form.errors}"
-
-    def test_form_accepts_all_statuses(self, db):
-        """Form accepts all valid statuses."""
-        valid_statuses = ["PLANNED", "IN_PROGRESS", "COMPLETED", "PAUSED", "DNF"]
-
-        for status in valid_statuses:
-            data = {
-                "title": f"Test {status}",
-                "media_type": "BOOK",
-                "status": status,
-            }
-            form = MediaForm(data=data)
-            assert form.is_valid(), f"Failed for {status}: {form.errors}"
-
-    def test_form_accepts_all_scores(self, db):
-        """Form accepts all valid scores."""
-        for score in range(1, 11):
-            data = {
-                "title": f"Test score {score}",
-                "media_type": "BOOK",
-                "status": "COMPLETED",
-                "score": score,
-            }
-            form = MediaForm(data=data)
-            assert form.is_valid(), f"Failed for score {score}: {form.errors}"
+        form = MediaForm(data=data)
+        assert form.is_valid(), f"Failed for score {score}: {form.errors}"

--- a/src/tests/core/test_management_commands.py
+++ b/src/tests/core/test_management_commands.py
@@ -17,177 +17,179 @@ from django.core.management.base import CommandError
 from core.models import Media
 
 
-class TestExportBackupCommand:
-    """Tests for the export_backup management command."""
+def test_export_creates_backup(db):
+    """The export_backup command creates a backup file."""
+    with TemporaryDirectory() as tmpdir:
+        out = StringIO()
+        result = call_command("export_backup", f"--output={tmpdir}", stdout=out)
 
-    def test_export_creates_backup(self, db):
-        """The export_backup command creates a backup file."""
-        with TemporaryDirectory() as tmpdir:
+        # The command should return the path to the backup
+        assert result is not None
+        backup_path = Path(result)
+        assert backup_path.exists()
+        assert backup_path.name.startswith("datakult_backup_")
+
+
+def test_export_with_custom_filename(db):
+    """The export_backup command accepts a custom filename."""
+    with TemporaryDirectory() as tmpdir:
+        out = StringIO()
+        result = call_command(
+            "export_backup",
+            f"--output={tmpdir}",
+            "--filename=my_backup.tar.gz",
+            stdout=out,
+        )
+
+        backup_path = Path(result)
+        assert backup_path.name == "my_backup.tar.gz"
+
+
+def test_export_displays_success_message(db):
+    """The command displays a success message."""
+    with TemporaryDirectory() as tmpdir:
+        out = StringIO()
+        call_command("export_backup", f"--output={tmpdir}", stdout=out)
+
+        output = out.getvalue()
+        assert "Backup created successfully" in output
+
+
+def test_export_includes_media_data(db):
+    """The exported backup includes media data."""
+    Media.objects.create(title="Test Media", media_type="BOOK")
+
+    with TemporaryDirectory() as tmpdir:
+        out = StringIO()
+        result = call_command("export_backup", f"--output={tmpdir}", stdout=out)
+
+        backup_path = Path(result)
+        with tarfile.open(backup_path, "r:gz") as tar:
+            db_file = tar.extractfile("database.json")
+            db_data = json.loads(db_file.read())
+
+            media_entries = [entry for entry in db_data if entry["model"] == "core.media"]
+            assert len(media_entries) == 1
+
+
+def test_export_with_keep_rotates_old_backups(db):
+    """The export_backup command with --keep rotates backups correctly."""
+    with TemporaryDirectory() as tmpdir:
+        # Create 4 backups with keep=2
+        for _ in range(4):
             out = StringIO()
-            result = call_command("export_backup", f"--output={tmpdir}", stdout=out)
+            call_command("export_backup", f"--output={tmpdir}", "--keep=2", stdout=out)
 
-            # The command should return the path to the backup
-            assert result is not None
-            backup_path = Path(result)
-            assert backup_path.exists()
-            assert backup_path.name.startswith("datakult_backup_")
+        # Only 2 most recent should remain
+        backups = sorted(Path(tmpdir).glob("datakult_backup_*.tar.gz"), key=lambda p: p.stat().st_mtime, reverse=True)
+        assert len(backups) == 2
 
-    def test_export_with_custom_filename(self, db):
-        """The export_backup command accepts a custom filename."""
-        with TemporaryDirectory() as tmpdir:
-            out = StringIO()
-            result = call_command(
-                "export_backup",
-                f"--output={tmpdir}",
-                "--filename=my_backup.tar.gz",
-                stdout=out,
-            )
+        # Check that rotation message was displayed
+        output = out.getvalue()
+        assert "Deleting old backup" in output or "Deleted" in output
 
-            backup_path = Path(result)
-            assert backup_path.name == "my_backup.tar.gz"
 
-    def test_export_displays_success_message(self, db):
-        """The command displays a success message."""
-        with TemporaryDirectory() as tmpdir:
+def test_export_without_keep_no_rotation(db):
+    """The export_backup command without --keep doesn't delete old backups."""
+    with TemporaryDirectory() as tmpdir:
+        # Create 3 backups without specifying --keep
+        for _ in range(3):
             out = StringIO()
             call_command("export_backup", f"--output={tmpdir}", stdout=out)
 
-            output = out.getvalue()
-            assert "Backup created successfully" in output
-
-    def test_export_includes_media_data(self, db):
-        """The exported backup includes media data."""
-        Media.objects.create(title="Test Media", media_type="BOOK")
-
-        with TemporaryDirectory() as tmpdir:
-            out = StringIO()
-            result = call_command("export_backup", f"--output={tmpdir}", stdout=out)
-
-            backup_path = Path(result)
-            with tarfile.open(backup_path, "r:gz") as tar:
-                db_file = tar.extractfile("database.json")
-                db_data = json.loads(db_file.read())
-
-                media_entries = [entry for entry in db_data if entry["model"] == "core.media"]
-                assert len(media_entries) == 1
-
-    def test_export_with_keep_rotates_old_backups(self, db):
-        """The export_backup command with --keep rotates backups correctly."""
-        with TemporaryDirectory() as tmpdir:
-            # Create 4 backups with keep=2
-            for _ in range(4):
-                out = StringIO()
-                call_command("export_backup", f"--output={tmpdir}", "--keep=2", stdout=out)
-
-            # Only 2 most recent should remain
-            backups = sorted(
-                Path(tmpdir).glob("datakult_backup_*.tar.gz"), key=lambda p: p.stat().st_mtime, reverse=True
-            )
-            assert len(backups) == 2
-
-            # Check that rotation message was displayed
-            output = out.getvalue()
-            assert "Deleting old backup" in output or "Deleted" in output
-
-    def test_export_without_keep_no_rotation(self, db):
-        """The export_backup command without --keep doesn't delete old backups."""
-        with TemporaryDirectory() as tmpdir:
-            # Create 3 backups without specifying --keep
-            for _ in range(3):
-                out = StringIO()
-                call_command("export_backup", f"--output={tmpdir}", stdout=out)
-
-            # All 3 should remain
-            backups = list(Path(tmpdir).glob("datakult_backup_*.tar.gz"))
-            assert len(backups) == 3
+        # All 3 should remain
+        backups = list(Path(tmpdir).glob("datakult_backup_*.tar.gz"))
+        assert len(backups) == 3
 
 
-class TestImportBackupCommand:
-    """Tests for the import_backup management command."""
+def test_import_requires_file_argument(db):
+    """The import_backup command requires a backup file argument."""
+    with pytest.raises(CommandError, match="the following arguments are required"):
+        call_command("import_backup")
 
-    def test_import_requires_file_argument(self, db):
-        """The import_backup command requires a backup file argument."""
-        with pytest.raises(CommandError, match="the following arguments are required"):
-            call_command("import_backup")
 
-    def test_import_rejects_nonexistent_file(self, db):
-        """The import_backup command rejects a non-existent file."""
-        with pytest.raises(CommandError, match="Backup file not found"):
-            call_command("import_backup", "/nonexistent/backup.tar.gz")
+def test_import_rejects_nonexistent_file(db):
+    """The import_backup command rejects a non-existent file."""
+    with pytest.raises(CommandError, match="Backup file not found"):
+        call_command("import_backup", "/nonexistent/backup.tar.gz")
 
-    def test_import_rejects_invalid_format(self, db):
-        """The import_backup command rejects files with invalid format."""
-        with TemporaryDirectory() as tmpdir:
-            # Create a non-.tar.gz file
-            invalid_file = Path(tmpdir) / "backup.txt"
-            invalid_file.write_text("not a backup")
 
-            with pytest.raises(CommandError, match="Invalid backup file format"):
-                call_command("import_backup", str(invalid_file))
+def test_import_rejects_invalid_format(db):
+    """The import_backup command rejects files with invalid format."""
+    with TemporaryDirectory() as tmpdir:
+        # Create a non-.tar.gz file
+        invalid_file = Path(tmpdir) / "backup.txt"
+        invalid_file.write_text("not a backup")
 
-    def test_import_restores_media_data(self, db):
-        """The import_backup command restores media data."""
-        # Create a media entry and backup
-        original_media = Media.objects.create(title="Original Media", media_type="BOOK", status="COMPLETED")
+        with pytest.raises(CommandError, match="Invalid backup file format"):
+            call_command("import_backup", str(invalid_file))
 
-        with TemporaryDirectory() as tmpdir:
-            # Create a backup
-            out = StringIO()
-            backup_path = Path(call_command("export_backup", f"--output={tmpdir}", stdout=out))
 
-            # Clear the database
-            Media.objects.all().delete()
-            assert Media.objects.count() == 0
+def test_import_restores_media_data(db):
+    """The import_backup command restores media data."""
+    # Create a media entry and backup
+    original_media = Media.objects.create(title="Original Media", media_type="BOOK", status="COMPLETED")
 
-            # Import the backup without --flush (merge mode)
-            call_command("import_backup", str(backup_path))
+    with TemporaryDirectory() as tmpdir:
+        # Create a backup
+        out = StringIO()
+        backup_path = Path(call_command("export_backup", f"--output={tmpdir}", stdout=out))
 
-            # Verify the media is restored
-            assert Media.objects.count() == 1
-            restored_media = Media.objects.first()
-            assert restored_media.title == original_media.title
-            assert restored_media.status == original_media.status
+        # Clear the database
+        Media.objects.all().delete()
+        assert Media.objects.count() == 0
 
-    def test_import_with_flush_replaces_data(self, db):
-        """The import_backup command with --flush replaces all data."""
-        # Create initial media and backup
-        Media.objects.create(title="Original", media_type="BOOK")
+        # Import the backup without --flush (merge mode)
+        call_command("import_backup", str(backup_path))
 
-        with TemporaryDirectory() as tmpdir:
-            # Create a backup
-            out = StringIO()
-            backup_path = Path(call_command("export_backup", f"--output={tmpdir}", stdout=out))
+        # Verify the media is restored
+        assert Media.objects.count() == 1
+        restored_media = Media.objects.first()
+        assert restored_media.title == original_media.title
+        assert restored_media.status == original_media.status
 
-            # Add new media (not in backup)
-            Media.objects.create(title="New Media", media_type="FILM")
-            assert Media.objects.count() == 2
 
-            # Import with --flush should remove "New Media"
-            call_command("import_backup", str(backup_path), "--flush")
+def test_import_with_flush_replaces_data(db):
+    """The import_backup command with --flush replaces all data."""
+    # Create initial media and backup
+    Media.objects.create(title="Original", media_type="BOOK")
 
-            # Only the original media should remain
-            assert Media.objects.count() == 1
-            assert Media.objects.first().title == "Original"
+    with TemporaryDirectory() as tmpdir:
+        # Create a backup
+        out = StringIO()
+        backup_path = Path(call_command("export_backup", f"--output={tmpdir}", stdout=out))
 
-    def test_import_with_no_media_flag(self, db):
-        """The import_backup command with --no-media skips media files."""
-        Media.objects.create(title="Test", media_type="BOOK")
+        # Add new media (not in backup)
+        Media.objects.create(title="New Media", media_type="FILM")
+        assert Media.objects.count() == 2
 
-        with TemporaryDirectory() as tmpdir:
-            # Create a backup
-            out = StringIO()
-            backup_path = Path(call_command("export_backup", f"--output={tmpdir}", stdout=out))
+        # Import with --flush should remove "New Media"
+        call_command("import_backup", str(backup_path), "--flush")
 
-            # Clear database
-            Media.objects.all().delete()
+        # Only the original media should remain
+        assert Media.objects.count() == 1
+        assert Media.objects.first().title == "Original"
 
-            # Import without media files
-            out = StringIO()
-            call_command("import_backup", str(backup_path), "--no-media", stdout=out)
 
-            # Database should be restored
-            assert Media.objects.count() == 1
+def test_import_with_no_media_flag(db):
+    """The import_backup command with --no-media skips media files."""
+    Media.objects.create(title="Test", media_type="BOOK")
 
-            # Check output mentions skipping media
-            output = out.getvalue()
-            assert "Skipping media files import" in output
+    with TemporaryDirectory() as tmpdir:
+        # Create a backup
+        out = StringIO()
+        backup_path = Path(call_command("export_backup", f"--output={tmpdir}", stdout=out))
+
+        # Clear database
+        Media.objects.all().delete()
+
+        # Import without media files
+        out = StringIO()
+        call_command("import_backup", str(backup_path), "--no-media", stdout=out)
+
+        # Database should be restored
+        assert Media.objects.count() == 1
+
+        # Check output mentions skipping media
+        output = out.getvalue()
+        assert "Skipping media files import" in output

--- a/src/tests/core/test_models.py
+++ b/src/tests/core/test_models.py
@@ -16,395 +16,374 @@ from PIL import Image
 from core.models import MAX_FILE_SIZE_MB, Media, SavedView, compress_image
 
 
-class TestAgentModel:
-    """Tests for the Agent model."""
-
-    def test_agent_str_representation(self, agent):
-        """The string representation of an agent is its name."""
-        assert str(agent) == agent.name
-
-    def test_agent_updated_at_auto_updates_on_save(self, agent, db):
-        """The updated_at field is automatically updated when agent is saved."""
-        # Freeze time at a specific moment
-        with freeze_time("2024-01-01 12:00:00") as frozen_time:
-            # Create/update agent at this frozen time
-            agent.name = "Initial Name"
-            agent.save()
-            agent.refresh_from_db()
-            original_updated_at = agent.updated_at
-
-            # Move time forward by 1 hour
-            frozen_time.move_to("2024-01-01 13:00:00")
-
-            # Update and save again
-            agent.name = "Updated Name"
-            agent.save()
-
-            # Refresh from database
-            agent.refresh_from_db()
-
-            # updated_at should be more recent than original
-            assert agent.updated_at > original_updated_at
+def test_agent_str_representation(agent):
+    """The string representation of an agent is its name."""
+    assert str(agent) == agent.name
 
 
-class TestMediaModel:
-    """Tests for the Media model."""
+def test_agent_updated_at_auto_updates_on_save(agent, db):
+    """The updated_at field is automatically updated when agent is saved."""
+    with freeze_time("2024-01-01 12:00:00") as frozen_time:
+        agent.name = "Initial Name"
+        agent.save()
+        agent.refresh_from_db()
+        original_updated_at = agent.updated_at
 
-    def test_media_str_representation(self, media):
-        """The string representation of a media is its title."""
-        assert str(media) == media.title
+        frozen_time.move_to("2024-01-01 13:00:00")
 
-    def test_media_pub_year_validation_too_early(self, db):
-        """Publication year before -4000 is rejected."""
-        media = Media(
-            title="Ancient Work",
-            media_type="BOOK",
-            pub_year=-5000,
-        )
+        agent.name = "Updated Name"
+        agent.save()
 
-        with pytest.raises(ValidationError) as exc_info:
-            media.full_clean()
-        assert "pub_year" in exc_info.value.message_dict
+        agent.refresh_from_db()
 
-    def test_media_pub_year_validation_too_late(self, db):
-        """Publication year after 2200 is rejected."""
-        media = Media(
-            title="Future Work",
-            media_type="BOOK",
-            pub_year=2500,
-        )
+        assert agent.updated_at > original_updated_at
 
-        with pytest.raises(ValidationError) as exc_info:
-            media.full_clean()
-        assert "pub_year" in exc_info.value.message_dict
 
-    def test_media_pub_year_validation_valid_range(self, db):
-        """Publication year within valid range is accepted."""
-        media = Media(
-            title="Normal Work",
-            media_type="BOOK",
-            pub_year=2024,
-        )
-        # Should not raise
+def test_media_str_representation(media):
+    """The string representation of a media is its title."""
+    assert str(media) == media.title
+
+
+def test_media_pub_year_validation_too_early(db):
+    """Publication year before -4000 is rejected."""
+    media = Media(
+        title="Ancient Work",
+        media_type="BOOK",
+        pub_year=-5000,
+    )
+
+    with pytest.raises(ValidationError) as exc_info:
         media.full_clean()
+    assert "pub_year" in exc_info.value.message_dict
 
-    def test_media_cover_image_compression(self, db):
-        """Cover images are automatically compressed and resized when saved."""
-        # Create a large test image (1920x1080)
-        img = Image.new("RGB", (1920, 1080), color="red")
-        img_io = BytesIO()
-        img.save(img_io, format="PNG")
-        img_io.seek(0)
 
-        # Create a Media object with the large image
-        cover_file = SimpleUploadedFile("test_cover.png", img_io.read(), content_type="image/png")
-        media = Media(
-            title="Test Media",
-            media_type="BOOK",
-            cover=cover_file,
-        )
+def test_media_pub_year_validation_too_late(db):
+    """Publication year after 2200 is rejected."""
+    media = Media(
+        title="Future Work",
+        media_type="BOOK",
+        pub_year=2500,
+    )
+
+    with pytest.raises(ValidationError) as exc_info:
+        media.full_clean()
+    assert "pub_year" in exc_info.value.message_dict
+
+
+def test_media_pub_year_validation_valid_range(db):
+    """Publication year within valid range is accepted."""
+    media = Media(
+        title="Normal Work",
+        media_type="BOOK",
+        pub_year=2024,
+    )
+    # Should not raise
+    media.full_clean()
+
+
+def test_media_cover_image_compression(db):
+    """Cover images are automatically compressed and resized when saved."""
+    # Create a large test image (1920x1080)
+    img = Image.new("RGB", (1920, 1080), color="red")
+    img_io = BytesIO()
+    img.save(img_io, format="PNG")
+    img_io.seek(0)
+
+    # Create a Media object with the large image
+    cover_file = SimpleUploadedFile("test_cover.png", img_io.read(), content_type="image/png")
+    media = Media(
+        title="Test Media",
+        media_type="BOOK",
+        cover=cover_file,
+    )
+    media.save()
+
+    # Verify the image was saved
+    assert media.cover
+    assert media.cover.name
+
+    # Open the saved image and check dimensions
+    saved_image = Image.open(media.cover)
+    width, height = saved_image.size
+
+    # Image should be resized to fit within 800x800
+    assert width <= 800
+    assert height <= 800
+
+    # Aspect ratio should be preserved (1920:1080 = 16:9)
+    # The image should be 800x450 (preserving 16:9 ratio)
+    assert width == 800
+    assert height == 450
+
+    # Cleanup
+    media.cover.delete(save=False)
+    media.delete()
+
+
+def test_media_updated_at_auto_updates_on_save(media, db):
+    """The updated_at field is automatically updated when media is saved."""
+    with freeze_time("2024-01-01 12:00:00") as frozen_time:
+        media.title = "Initial Title"
+        media.save()
+        media.refresh_from_db()
+        original_updated_at = media.updated_at
+
+        frozen_time.move_to("2024-01-01 13:00:00")
+
+        media.title = "Updated Title"
         media.save()
 
-        # Verify the image was saved
-        assert media.cover
-        assert media.cover.name
+        media.refresh_from_db()
 
-        # Open the saved image and check dimensions
-        saved_image = Image.open(media.cover)
-        width, height = saved_image.size
-
-        # Image should be resized to fit within 800x800
-        assert width <= 800
-        assert height <= 800
-
-        # Aspect ratio should be preserved (1920:1080 = 16:9)
-        # The image should be 800x450 (preserving 16:9 ratio)
-        assert width == 800
-        assert height == 450
-
-        # Cleanup
-        media.cover.delete(save=False)
-        media.delete()
-
-    def test_media_updated_at_auto_updates_on_save(self, media, db):
-        """The updated_at field is automatically updated when media is saved."""
-        # Freeze time at a specific moment
-        with freeze_time("2024-01-01 12:00:00") as frozen_time:
-            # Create/update media at this frozen time
-            media.title = "Initial Title"
-            media.save()
-            media.refresh_from_db()
-            original_updated_at = media.updated_at
-
-            # Move time forward by 1 hour
-            frozen_time.move_to("2024-01-01 13:00:00")
-
-            # Update and save again
-            media.title = "Updated Title"
-            media.save()
-
-            # Refresh from database
-            media.refresh_from_db()
-
-            # updated_at should be more recent than original
-            assert media.updated_at > original_updated_at
+        assert media.updated_at > original_updated_at
 
 
-class TestCompressImageSecurity:
-    """Tests for security features of the compress_image function."""
+def test_compress_image_file_size_validation():
+    """Files exceeding MAX_FILE_SIZE_MB are rejected."""
+    oversized_file = BytesIO()
+    oversized_file.size = (MAX_FILE_SIZE_MB + 1) * 1024 * 1024
 
-    def test_compress_image_file_size_validation(self):
-        """Files exceeding MAX_FILE_SIZE_MB are rejected."""
-        # Create a mock file object with size exceeding the limit
-        oversized_file = BytesIO()
-        oversized_file.size = (MAX_FILE_SIZE_MB + 1) * 1024 * 1024
-
-        with pytest.raises(ValidationError) as exc_info:
-            compress_image(oversized_file)
-        assert "exceeds" in str(exc_info.value).lower()
-
-    def test_compress_image_invalid_file(self):
-        """Invalid or corrupted files are rejected."""
-        invalid_file = BytesIO(b"This is not an image")
-
-        with pytest.raises(ValidationError) as exc_info:
-            compress_image(invalid_file)
-        assert "invalid" in str(exc_info.value).lower() or "corrupted" in str(exc_info.value).lower()
-
-    def test_compress_image_unsupported_format(self):
-        """Unsupported image formats are rejected."""
-        # Create a TIFF image (not in ALLOWED_IMAGE_TYPES)
-        img = Image.new("RGB", (100, 100), color="blue")
-        img_io = BytesIO()
-        img.save(img_io, format="TIFF")
-        img_io.seek(0)
-
-        with pytest.raises(ValidationError) as exc_info:
-            compress_image(img_io)
-        assert "unsupported" in str(exc_info.value).lower()
-
-    def test_compress_image_exif_orientation_preserved(self):
-        """EXIF orientation metadata is correctly applied."""
-        # Create an image with EXIF orientation
-        img = Image.new("RGB", (200, 100), color="green")
-
-        # Add EXIF data for rotation (orientation tag 6 = rotate 90 CW)
-        exif = img.getexif()
-        exif[0x0112] = 6  # Orientation tag
-        img_io = BytesIO()
-        img.save(img_io, format="JPEG", exif=exif)
-        img_io.seek(0)
-
-        # Compress the image
-        compressed = compress_image(img_io)
-
-        # Open the compressed image
-        compressed.seek(0)
-        result_img = Image.open(compressed)
-
-        # The image should have been rotated (width and height swapped)
-        # Original was 200x100, after 90° rotation should be 100x200
-        assert result_img.width == 100
-        assert result_img.height == 200
-
-    def test_compress_image_rgba_conversion(self):
-        """RGBA images are correctly converted to RGB."""
-        # Create an RGBA image
-        img = Image.new("RGBA", (100, 100), color=(255, 0, 0, 128))
-        img_io = BytesIO()
-        img.save(img_io, format="PNG")
-        img_io.seek(0)
-
-        # Compress the image
-        compressed = compress_image(img_io)
-
-        # Open the compressed image
-        compressed.seek(0)
-        result_img = Image.open(compressed)
-
-        # Should be converted to RGB
-        assert result_img.mode == "RGB"
-        # Should be saved as JPEG
-        assert result_img.format == "JPEG"
-
-    def test_compress_image_supported_formats(self):
-        """Normal JPEG and PNG images are processed successfully."""
-        # Test JPEG
-        jpeg_img = Image.new("RGB", (1000, 1000), color="red")
-        jpeg_io = BytesIO()
-        jpeg_img.save(jpeg_io, format="JPEG")
-        jpeg_io.seek(0)
-
-        compressed_jpeg = compress_image(jpeg_io)
-        compressed_jpeg.seek(0)
-        result_jpeg = Image.open(compressed_jpeg)
-        assert result_jpeg.width <= 800
-        assert result_jpeg.height <= 800
-
-        # Test PNG (should be converted to JPEG)
-        png_img = Image.new("RGB", (1000, 1000), color="blue")
-        png_io = BytesIO()
-        png_img.save(png_io, format="PNG")
-        png_io.seek(0)
-
-        compressed_png = compress_image(png_io)
-        compressed_png.seek(0)
-        result_png = Image.open(compressed_png)
-        assert result_png.format == "JPEG"
-        assert result_png.width <= 800
-        assert result_png.height <= 800
+    with pytest.raises(ValidationError) as exc_info:
+        compress_image(oversized_file)
+    assert "exceeds" in str(exc_info.value).lower()
 
 
-class TestSavedViewModel:
-    """Tests for the SavedView model."""
+def test_compress_image_invalid_file():
+    """Invalid or corrupted files are rejected."""
+    invalid_file = BytesIO(b"This is not an image")
 
-    def test_saved_view_str_representation(self, user, db):
-        """The string representation includes username and view name."""
+    with pytest.raises(ValidationError) as exc_info:
+        compress_image(invalid_file)
+    assert "invalid" in str(exc_info.value).lower() or "corrupted" in str(exc_info.value).lower()
 
-        saved_view = SavedView.objects.create(
-            user=user,
-            name="My Favorite Books",
-        )
 
-        assert str(saved_view) == f"{user.username} - My Favorite Books"
+def test_compress_image_unsupported_format():
+    """Unsupported image formats are rejected."""
+    # Create a TIFF image (not in ALLOWED_IMAGE_TYPES)
+    img = Image.new("RGB", (100, 100), color="blue")
+    img_io = BytesIO()
+    img.save(img_io, format="TIFF")
+    img_io.seek(0)
 
-    def test_saved_view_unique_together_constraint(self, user, db):
-        """User cannot have multiple views with the same name."""
-        from django.db import IntegrityError
+    with pytest.raises(ValidationError) as exc_info:
+        compress_image(img_io)
+    assert "unsupported" in str(exc_info.value).lower()
 
-        # Create first view
+
+def test_compress_image_exif_orientation_preserved():
+    """EXIF orientation metadata is correctly applied."""
+    img = Image.new("RGB", (200, 100), color="green")
+
+    # Add EXIF data for rotation (orientation tag 6 = rotate 90 CW)
+    exif = img.getexif()
+    exif[0x0112] = 6  # Orientation tag
+    img_io = BytesIO()
+    img.save(img_io, format="JPEG", exif=exif)
+    img_io.seek(0)
+
+    compressed = compress_image(img_io)
+
+    compressed.seek(0)
+    result_img = Image.open(compressed)
+
+    # The image should have been rotated (width and height swapped)
+    # Original was 200x100, after 90° rotation should be 100x200
+    assert result_img.width == 100
+    assert result_img.height == 200
+
+
+def test_compress_image_rgba_conversion():
+    """RGBA images are correctly converted to RGB."""
+    img = Image.new("RGBA", (100, 100), color=(255, 0, 0, 128))
+    img_io = BytesIO()
+    img.save(img_io, format="PNG")
+    img_io.seek(0)
+
+    compressed = compress_image(img_io)
+
+    compressed.seek(0)
+    result_img = Image.open(compressed)
+
+    # Should be converted to RGB
+    assert result_img.mode == "RGB"
+    # Should be saved as JPEG
+    assert result_img.format == "JPEG"
+
+
+def test_compress_image_supported_formats():
+    """Normal JPEG and PNG images are processed successfully."""
+    # Test JPEG
+    jpeg_img = Image.new("RGB", (1000, 1000), color="red")
+    jpeg_io = BytesIO()
+    jpeg_img.save(jpeg_io, format="JPEG")
+    jpeg_io.seek(0)
+
+    compressed_jpeg = compress_image(jpeg_io)
+    compressed_jpeg.seek(0)
+    result_jpeg = Image.open(compressed_jpeg)
+    assert result_jpeg.width <= 800
+    assert result_jpeg.height <= 800
+
+    # Test PNG (should be converted to JPEG)
+    png_img = Image.new("RGB", (1000, 1000), color="blue")
+    png_io = BytesIO()
+    png_img.save(png_io, format="PNG")
+    png_io.seek(0)
+
+    compressed_png = compress_image(png_io)
+    compressed_png.seek(0)
+    result_png = Image.open(compressed_png)
+    assert result_png.format == "JPEG"
+    assert result_png.width <= 800
+    assert result_png.height <= 800
+
+
+def test_saved_view_str_representation(user, db):
+    """The string representation includes username and view name."""
+    saved_view = SavedView.objects.create(
+        user=user,
+        name="My Favorite Books",
+    )
+
+    assert str(saved_view) == f"{user.username} - My Favorite Books"
+
+
+def test_saved_view_unique_together_constraint(user, db):
+    """User cannot have multiple views with the same name."""
+    from django.db import IntegrityError
+
+    # Create first view
+    SavedView.objects.create(user=user, name="My View")
+
+    # Attempting to create another view with the same name should fail
+    with pytest.raises(IntegrityError):
         SavedView.objects.create(user=user, name="My View")
 
-        # Attempting to create another view with the same name should fail
-        with pytest.raises(IntegrityError):
-            SavedView.objects.create(user=user, name="My View")
 
-    def test_saved_view_default_values(self, user, db):
-        """SavedView has correct default values for filters and preferences."""
+def test_saved_view_default_values(user, db):
+    """SavedView has correct default values for filters and preferences."""
+    saved_view = SavedView.objects.create(user=user, name="Default View")
 
-        saved_view = SavedView.objects.create(user=user, name="Default View")
+    assert saved_view.filter_types == []
+    assert saved_view.filter_statuses == []
+    assert saved_view.filter_scores == []
+    assert saved_view.filter_contributor_id is None
+    assert saved_view.filter_review_from == ""
+    assert saved_view.filter_review_to == ""
+    assert saved_view.filter_has_review == ""
+    assert saved_view.filter_has_cover == ""
+    assert saved_view.sort == "-review_date"
+    assert saved_view.view_mode == "grid"
 
-        assert saved_view.filter_types == []
-        assert saved_view.filter_statuses == []
-        assert saved_view.filter_scores == []
-        assert saved_view.filter_contributor_id is None
-        assert saved_view.filter_review_from == ""
-        assert saved_view.filter_review_to == ""
-        assert saved_view.filter_has_review == ""
-        assert saved_view.filter_has_cover == ""
-        assert saved_view.sort == "-review_date"
-        assert saved_view.view_mode == "grid"
 
-    def test_saved_view_stores_filter_parameters(self, user, db):
-        """SavedView correctly stores all filter parameters."""
+def test_saved_view_stores_filter_parameters(user, db):
+    """SavedView correctly stores all filter parameters."""
+    saved_view = SavedView.objects.create(
+        user=user,
+        name="Filtered View",
+        filter_types=["BOOK", "FILM"],
+        filter_statuses=["COMPLETED"],
+        filter_scores=["8", "9", "10"],
+        filter_contributor_id=1,
+        filter_review_from="2024-01-01",
+        filter_review_to="2024-12-31",
+        filter_has_review="yes",
+        filter_has_cover="no",
+        sort="-score",
+        view_mode="list",
+    )
 
-        saved_view = SavedView.objects.create(
-            user=user,
-            name="Filtered View",
-            filter_types=["BOOK", "FILM"],
-            filter_statuses=["COMPLETED"],
-            filter_scores=["8", "9", "10"],
-            filter_contributor_id=1,
-            filter_review_from="2024-01-01",
-            filter_review_to="2024-12-31",
-            filter_has_review="yes",
-            filter_has_cover="no",
-            sort="-score",
-            view_mode="list",
-        )
+    saved_view.refresh_from_db()
+
+    assert saved_view.filter_types == ["BOOK", "FILM"]
+    assert saved_view.filter_statuses == ["COMPLETED"]
+    assert saved_view.filter_scores == ["8", "9", "10"]
+    assert saved_view.filter_contributor_id == 1
+    assert saved_view.filter_review_from == "2024-01-01"
+    assert saved_view.filter_review_to == "2024-12-31"
+    assert saved_view.filter_has_review == "yes"
+    assert saved_view.filter_has_cover == "no"
+    assert saved_view.sort == "-score"
+    assert saved_view.view_mode == "list"
+
+
+def test_saved_view_updated_at_auto_updates(user, db):
+    """The updated_at field is automatically updated on save."""
+    with freeze_time("2024-01-01 12:00:00") as frozen_time:
+        saved_view = SavedView.objects.create(user=user, name="Test View")
+        saved_view.refresh_from_db()
+        original_updated_at = saved_view.updated_at
+
+        frozen_time.move_to("2024-01-01 13:00:00")
+
+        saved_view.name = "Updated View Name"
+        saved_view.save()
 
         saved_view.refresh_from_db()
 
-        assert saved_view.filter_types == ["BOOK", "FILM"]
-        assert saved_view.filter_statuses == ["COMPLETED"]
-        assert saved_view.filter_scores == ["8", "9", "10"]
-        assert saved_view.filter_contributor_id == 1
-        assert saved_view.filter_review_from == "2024-01-01"
-        assert saved_view.filter_review_to == "2024-12-31"
-        assert saved_view.filter_has_review == "yes"
-        assert saved_view.filter_has_cover == "no"
-        assert saved_view.sort == "-score"
-        assert saved_view.view_mode == "list"
+        assert saved_view.updated_at > original_updated_at
 
-    def test_saved_view_updated_at_auto_updates(self, user, db):
-        """The updated_at field is automatically updated on save."""
-        # Freeze time at a specific moment
-        with freeze_time("2024-01-01 12:00:00") as frozen_time:
-            # Create saved view at this frozen time
-            saved_view = SavedView.objects.create(user=user, name="Test View")
-            saved_view.refresh_from_db()
-            original_updated_at = saved_view.updated_at
 
-            # Move time forward by 1 hour
-            frozen_time.move_to("2024-01-01 13:00:00")
+def test_get_filter_url_with_defaults(user, db):
+    """get_filter_url returns URL with default sort and view_mode."""
+    saved_view = SavedView.objects.create(user=user, name="Default View")
 
-            # Update and save again
-            saved_view.name = "Updated View Name"
-            saved_view.save()
+    url = saved_view.get_filter_url()
 
-            # Refresh from database
-            saved_view.refresh_from_db()
+    assert url == "/?sort=-review_date&view_mode=grid"
 
-            # updated_at should be more recent than original
-            assert saved_view.updated_at > original_updated_at
 
-    def test_get_filter_url_with_defaults(self, user, db):
-        """get_filter_url returns URL with default sort and view_mode."""
-        saved_view = SavedView.objects.create(user=user, name="Default View")
+def test_get_filter_url_with_list_filters(user, db):
+    """get_filter_url includes list filters (type, status, score) as repeated params."""
+    saved_view = SavedView.objects.create(
+        user=user,
+        name="Filtered View",
+        filter_types=["BOOK", "FILM"],
+        filter_statuses=["COMPLETED"],
+        filter_scores=["9", "10"],
+    )
 
-        url = saved_view.get_filter_url()
+    url = saved_view.get_filter_url()
 
-        assert url == "/?sort=-review_date&view_mode=grid"
+    # Check that list params are repeated
+    assert "type=BOOK" in url
+    assert "type=FILM" in url
+    assert "status=COMPLETED" in url
+    assert "score=9" in url
+    assert "score=10" in url
 
-    def test_get_filter_url_with_list_filters(self, user, db):
-        """get_filter_url includes list filters (type, status, score) as repeated params."""
-        saved_view = SavedView.objects.create(
-            user=user,
-            name="Filtered View",
-            filter_types=["BOOK", "FILM"],
-            filter_statuses=["COMPLETED"],
-            filter_scores=["9", "10"],
-        )
 
-        url = saved_view.get_filter_url()
+def test_get_filter_url_with_optional_filters(user, db):
+    """get_filter_url includes optional filters only when they have values."""
+    saved_view = SavedView.objects.create(
+        user=user,
+        name="Full Filters",
+        filter_contributor_id=42,
+        filter_review_from="2024-01",
+        filter_review_to="2024-12",
+        filter_has_review="yes",
+        filter_has_cover="no",
+    )
 
-        # Check that list params are repeated
-        assert "type=BOOK" in url
-        assert "type=FILM" in url
-        assert "status=COMPLETED" in url
-        assert "score=9" in url
-        assert "score=10" in url
+    url = saved_view.get_filter_url()
 
-    def test_get_filter_url_with_optional_filters(self, user, db):
-        """get_filter_url includes optional filters only when they have values."""
-        saved_view = SavedView.objects.create(
-            user=user,
-            name="Full Filters",
-            filter_contributor_id=42,
-            filter_review_from="2024-01",
-            filter_review_to="2024-12",
-            filter_has_review="yes",
-            filter_has_cover="no",
-        )
+    assert "contributor=42" in url
+    assert "review_from=2024-01" in url
+    assert "review_to=2024-12" in url
+    assert "has_review=yes" in url
+    assert "has_cover=no" in url
 
-        url = saved_view.get_filter_url()
 
-        assert "contributor=42" in url
-        assert "review_from=2024-01" in url
-        assert "review_to=2024-12" in url
-        assert "has_review=yes" in url
-        assert "has_cover=no" in url
+def test_get_filter_url_excludes_empty_optional_filters(user, db):
+    """get_filter_url excludes optional filters when empty."""
+    saved_view = SavedView.objects.create(
+        user=user,
+        name="Minimal View",
+        filter_contributor_id=None,  # Empty
+        filter_review_from="",  # Empty
+    )
 
-    def test_get_filter_url_excludes_empty_optional_filters(self, user, db):
-        """get_filter_url excludes optional filters when empty."""
-        saved_view = SavedView.objects.create(
-            user=user,
-            name="Minimal View",
-            filter_contributor_id=None,  # Empty
-            filter_review_from="",  # Empty
-        )
+    url = saved_view.get_filter_url()
 
-        url = saved_view.get_filter_url()
-
-        assert "contributor" not in url
-        assert "review_from" not in url
+    assert "contributor" not in url
+    assert "review_from" not in url

--- a/src/tests/core/test_musicbrainz.py
+++ b/src/tests/core/test_musicbrainz.py
@@ -12,75 +12,77 @@ from django.urls import reverse
 from core.services.musicbrainz import MusicBrainzResult
 
 
-class TestMusicBrainzSearchView:
-    """Tests for the musicbrainz_search_htmx view."""
+def test_returns_empty_for_short_query(logged_in_client):
+    """Returns empty results for queries shorter than minimum length."""
+    response = logged_in_client.get(reverse("musicbrainz_search_htmx"), {"q": "a"})
 
-    def test_returns_empty_for_short_query(self, logged_in_client):
-        """Returns empty results for queries shorter than minimum length."""
-        response = logged_in_client.get(reverse("musicbrainz_search_htmx"), {"q": "a"})
+    assert response.status_code == 200
+    assert "partials/musicbrainz/musicbrainz_suggestions.html" in [t.name for t in response.templates]
+    assert response.context["results"] == []
 
-        assert response.status_code == 200
-        assert "partials/musicbrainz/musicbrainz_suggestions.html" in [t.name for t in response.templates]
-        assert response.context["results"] == []
 
-    def test_returns_empty_for_empty_query(self, logged_in_client):
-        """Returns empty results for empty query."""
-        response = logged_in_client.get(reverse("musicbrainz_search_htmx"), {"q": ""})
+def test_returns_empty_for_empty_query(logged_in_client):
+    """Returns empty results for empty query."""
+    response = logged_in_client.get(reverse("musicbrainz_search_htmx"), {"q": ""})
 
-        assert response.status_code == 200
-        assert response.context["results"] == []
+    assert response.status_code == 200
+    assert response.context["results"] == []
 
-    @patch("core.views.get_musicbrainz_client")
-    def test_returns_search_results(self, mock_get_client, logged_in_client):
-        """Returns search results from MusicBrainz client."""
-        mock_client = MagicMock()
-        mock_client.search_releases.return_value = [
-            MusicBrainzResult(
-                mbid="test-mbid-123",
-                title="Abbey Road",
-                artists=["The Beatles"],
-                year=1969,
-                country="GB",
-                label="Apple Records",
-            )
-        ]
-        mock_get_client.return_value = mock_client
 
-        response = logged_in_client.get(reverse("musicbrainz_search_htmx"), {"q": "abbey road"})
+@patch("core.views.get_musicbrainz_client")
+def test_returns_search_results(mock_get_client, logged_in_client):
+    """Returns search results from MusicBrainz client."""
+    mock_client = MagicMock()
+    mock_client.search_releases.return_value = [
+        MusicBrainzResult(
+            mbid="test-mbid-123",
+            title="Abbey Road",
+            artists=["The Beatles"],
+            year=1969,
+            country="GB",
+            label="Apple Records",
+        )
+    ]
+    mock_get_client.return_value = mock_client
 
-        assert response.status_code == 200
-        assert len(response.context["results"]) == 1
-        assert response.context["results"][0].title == "Abbey Road"
-        mock_client.search_releases.assert_called_once()
+    response = logged_in_client.get(reverse("musicbrainz_search_htmx"), {"q": "abbey road"})
 
-    @patch("core.views.get_musicbrainz_client")
-    def test_handles_api_error_gracefully(self, mock_get_client, logged_in_client):
-        """Handles API errors gracefully and shows error message."""
-        mock_client = MagicMock()
-        mock_client.search_releases.side_effect = requests.RequestException("API Error")
-        mock_get_client.return_value = mock_client
+    assert response.status_code == 200
+    assert len(response.context["results"]) == 1
+    assert response.context["results"][0].title == "Abbey Road"
+    mock_client.search_releases.assert_called_once()
 
-        response = logged_in_client.get(reverse("musicbrainz_search_htmx"), {"q": "test query"})
 
-        assert response.status_code == 200
-        assert "error" in response.context
-        assert response.context["error"] == "Search failed"
+@patch("core.views.get_musicbrainz_client")
+def test_handles_api_error_gracefully(mock_get_client, logged_in_client):
+    """Handles API errors gracefully and shows error message."""
+    mock_client = MagicMock()
+    mock_client.search_releases.side_effect = requests.RequestException("API Error")
+    mock_get_client.return_value = mock_client
 
-    def test_preserves_media_id_in_context(self, logged_in_client):
-        """Preserves media_id in context for editing existing media."""
-        response = logged_in_client.get(reverse("musicbrainz_search_htmx"), {"q": "", "media_id": "42"})
+    response = logged_in_client.get(reverse("musicbrainz_search_htmx"), {"q": "test query"})
 
-        assert response.status_code == 200
-        assert response.context["media_id"] == "42"
+    assert response.status_code == 200
+    assert "error" in response.context
+    assert response.context["error"] == "Search failed"
 
-    @patch("core.views.get_musicbrainz_client")
-    def test_preserves_query_in_context(self, mock_get_client, logged_in_client):
-        """Preserves search query in context."""
-        mock_client = MagicMock()
-        mock_client.search_releases.return_value = []
-        mock_get_client.return_value = mock_client
 
-        response = logged_in_client.get(reverse("musicbrainz_search_htmx"), {"q": "test"})
+def test_preserves_media_id_in_context(logged_in_client):
+    """Preserves media_id in context for editing existing media."""
+    response = logged_in_client.get(reverse("musicbrainz_search_htmx"), {"q": "", "media_id": "42"})
 
-        assert response.status_code == 200
-        assert response.context["query"] == "test"
+    assert response.status_code == 200
+    assert response.context["media_id"] == "42"
+
+
+@patch("core.views.get_musicbrainz_client")
+def test_preserves_query_in_context(mock_get_client, logged_in_client):
+    """Preserves search query in context."""
+    mock_client = MagicMock()
+    mock_client.search_releases.return_value = []
+    mock_get_client.return_value = mock_client
+
+    response = logged_in_client.get(reverse("musicbrainz_search_htmx"), {"q": "test"})
+
+    assert response.status_code == 200
+    assert response.context["query"] == "test"

--- a/src/tests/core/test_tmdb.py
+++ b/src/tests/core/test_tmdb.py
@@ -15,78 +15,76 @@ from core.services.tmdb import (
 )
 
 
-class TestTMDBResult:
-    """Tests for the TMDBResult dataclass cover URL generation."""
+def test_cover_url_builds_w500_url():
+    """cover_url constructs the correct w500 image URL."""
+    result = TMDBResult(
+        tmdb_id=123,
+        title="Test",
+        original_title="Test",
+        year=2024,
+        overview="",
+        cover_path="/abc123.jpg",
+        media_type="movie",
+    )
 
-    def test_cover_url_builds_w500_url(self):
-        """cover_url constructs the correct w500 image URL."""
-        result = TMDBResult(
-            tmdb_id=123,
-            title="Test",
-            original_title="Test",
-            year=2024,
-            overview="",
-            cover_path="/abc123.jpg",
-            media_type="movie",
-        )
-
-        assert result.cover_url == f"{TMDB_IMAGE_BASE_URL}w500/abc123.jpg"
-
-    def test_cover_url_returns_none_when_no_path(self):
-        """cover_url returns None when cover_path is None."""
-        result = TMDBResult(
-            tmdb_id=123,
-            title="Test",
-            original_title="Test",
-            year=2024,
-            overview="",
-            cover_path=None,
-            media_type="movie",
-        )
-
-        assert result.cover_url is None
-
-    def test_cover_url_small_builds_w185_url(self):
-        """cover_url_small constructs the correct w185 thumbnail URL."""
-        result = TMDBResult(
-            tmdb_id=123,
-            title="Test",
-            original_title="Test",
-            year=2024,
-            overview="",
-            cover_path="/abc123.jpg",
-            media_type="movie",
-        )
-
-        assert result.cover_url_small == f"{TMDB_IMAGE_BASE_URL}w185/abc123.jpg"
+    assert result.cover_url == f"{TMDB_IMAGE_BASE_URL}w500/abc123.jpg"
 
 
-class TestTMDBClientValidation:
-    """Tests for TMDBClient input validation."""
+def test_cover_url_returns_none_when_no_path():
+    """cover_url returns None when cover_path is None."""
+    result = TMDBResult(
+        tmdb_id=123,
+        title="Test",
+        original_title="Test",
+        year=2024,
+        overview="",
+        cover_path=None,
+        media_type="movie",
+    )
 
-    def test_raises_error_without_api_key(self, settings):
-        """TMDBClient raises TMDBError when no API key is provided."""
-        settings.TMDB_API_KEY = ""
+    assert result.cover_url is None
 
-        with pytest.raises(TMDBError) as exc_info:
-            TMDBClient()
 
-        assert "TMDB API key is required" in str(exc_info.value)
+def test_cover_url_small_builds_w185_url():
+    """cover_url_small constructs the correct w185 thumbnail URL."""
+    result = TMDBResult(
+        tmdb_id=123,
+        title="Test",
+        original_title="Test",
+        year=2024,
+        overview="",
+        cover_path="/abc123.jpg",
+        media_type="movie",
+    )
 
-    def test_search_returns_empty_for_short_query(self):
-        """search_multi returns empty list for queries shorter than MIN_QUERY_LENGTH."""
-        client = TMDBClient(api_key="test-key")
+    assert result.cover_url_small == f"{TMDB_IMAGE_BASE_URL}w185/abc123.jpg"
 
-        # Query too short - no API call should be made
-        result = client.search_multi("a")
 
-        assert result == []
-        assert len("a") < MIN_QUERY_LENGTH
+def test_raises_error_without_api_key(settings):
+    """TMDBClient raises TMDBError when no API key is provided."""
+    settings.TMDB_API_KEY = ""
 
-    def test_search_returns_empty_for_empty_query(self):
-        """search_multi returns empty list for empty query."""
-        client = TMDBClient(api_key="test-key")
+    with pytest.raises(TMDBError) as exc_info:
+        TMDBClient()
 
-        result = client.search_multi("")
+    assert "TMDB API key is required" in str(exc_info.value)
 
-        assert result == []
+
+def test_search_returns_empty_for_short_query():
+    """search_multi returns empty list for queries shorter than MIN_QUERY_LENGTH."""
+    client = TMDBClient(api_key="test-key")
+
+    # Query too short - no API call should be made
+    result = client.search_multi("a")
+
+    assert result == []
+    assert len("a") < MIN_QUERY_LENGTH
+
+
+def test_search_returns_empty_for_empty_query():
+    """search_multi returns empty list for empty query."""
+    client = TMDBClient(api_key="test-key")
+
+    result = client.search_multi("")
+
+    assert result == []

--- a/src/tests/core/test_utils.py
+++ b/src/tests/core/test_utils.py
@@ -13,141 +13,141 @@ from core.models import Agent, Media
 from core.utils import create_backup, delete_orphan_agents_by_ids, get_datakult_version
 
 
-class TestDeleteOrphanAgentsByIds:
-    """Tests for the delete_orphan_agents_by_ids function."""
+def test_deletes_orphan_agent(db):
+    """An agent with no media is deleted."""
+    orphan = Agent.objects.create(name="Orphan Agent")
+    orphan_id = orphan.pk
 
-    def test_deletes_orphan_agent(self, db):
-        """An agent with no media is deleted."""
-        orphan = Agent.objects.create(name="Orphan Agent")
-        orphan_id = orphan.pk
+    deleted_count = delete_orphan_agents_by_ids([orphan_id])
 
-        deleted_count = delete_orphan_agents_by_ids([orphan_id])
-
-        assert deleted_count == 1
-        assert not Agent.objects.filter(pk=orphan_id).exists()
-
-    def test_keeps_agent_with_media(self, db):
-        """An agent linked to a media is not deleted."""
-        agent = Agent.objects.create(name="Active Agent")
-        media = Media.objects.create(title="Test Media", media_type="BOOK")
-        media.contributors.add(agent)
-
-        deleted_count = delete_orphan_agents_by_ids([agent.pk])
-
-        assert deleted_count == 0
-        assert Agent.objects.filter(pk=agent.pk).exists()
-
-    def test_mixed_agents(self, db):
-        """Only orphan agents are deleted from a mixed list."""
-        orphan = Agent.objects.create(name="Orphan")
-        active = Agent.objects.create(name="Active")
-        media = Media.objects.create(title="Test Media", media_type="BOOK")
-        media.contributors.add(active)
-
-        deleted_count = delete_orphan_agents_by_ids([orphan.pk, active.pk])
-
-        assert deleted_count == 1
-        assert not Agent.objects.filter(pk=orphan.pk).exists()
-        assert Agent.objects.filter(pk=active.pk).exists()
-
-    def test_empty_list(self, db):
-        """Returns 0 when given an empty list."""
-        deleted_count = delete_orphan_agents_by_ids([])
-
-        assert deleted_count == 0
-
-    def test_nonexistent_ids(self, db):
-        """Handles non-existent IDs gracefully."""
-        deleted_count = delete_orphan_agents_by_ids([99999, 88888])
-
-        assert deleted_count == 0
-
-    def test_handles_none_values(self, db):
-        """None values in the list are filtered out."""
-        orphan = Agent.objects.create(name="Orphan")
-
-        deleted_count = delete_orphan_agents_by_ids([None, orphan.pk, None])
-
-        assert deleted_count == 1
-
-    def test_handles_duplicate_ids(self, db):
-        """Duplicate IDs are handled correctly."""
-        orphan = Agent.objects.create(name="Orphan")
-
-        deleted_count = delete_orphan_agents_by_ids([orphan.pk, orphan.pk, orphan.pk])
-
-        assert deleted_count == 1
+    assert deleted_count == 1
+    assert not Agent.objects.filter(pk=orphan_id).exists()
 
 
-class TestGetDatakultVersion:
-    """Tests for the get_datakult_version function."""
+def test_keeps_agent_with_media(db):
+    """An agent linked to a media is not deleted."""
+    agent = Agent.objects.create(name="Active Agent")
+    media = Media.objects.create(title="Test Media", media_type="BOOK")
+    media.contributors.add(agent)
 
-    def test_returns_version_string(self):
-        """The function returns a version string."""
-        version = get_datakult_version()
+    deleted_count = delete_orphan_agents_by_ids([agent.pk])
 
-        assert isinstance(version, str)
-        assert version != ""
-
-    def test_version_format_or_unknown(self):
-        """The version is either in semver format or 'unknown'."""
-        version = get_datakult_version()
-
-        # Should be either a version number (e.g., "0.1.0") or "unknown"
-        assert version == "unknown" or version[0].isdigit()
+    assert deleted_count == 0
+    assert Agent.objects.filter(pk=agent.pk).exists()
 
 
-class TestCreateBackup:
-    """Tests for the create_backup function."""
+def test_mixed_agents(db):
+    """Only orphan agents are deleted from a mixed list."""
+    orphan = Agent.objects.create(name="Orphan")
+    active = Agent.objects.create(name="Active")
+    media = Media.objects.create(title="Test Media", media_type="BOOK")
+    media.contributors.add(active)
 
-    def test_creates_complete_backup(self, db):
-        """A backup file is created with all expected content."""
-        # Create a media entry to verify data backup
-        Media.objects.create(title="Test Media", media_type="BOOK")
+    deleted_count = delete_orphan_agents_by_ids([orphan.pk, active.pk])
 
-        with TemporaryDirectory() as tmpdir:
-            backup_path = create_backup(output_dir=Path(tmpdir))
+    assert deleted_count == 1
+    assert not Agent.objects.filter(pk=orphan.pk).exists()
+    assert Agent.objects.filter(pk=active.pk).exists()
 
-            # Verify file creation
-            assert backup_path.exists()
-            assert backup_path.suffix == ".gz"
-            assert backup_path.name.startswith("datakult_backup_")
 
-            # Verify archive contents
-            with tarfile.open(backup_path, "r:gz") as tar:
-                # Check metadata.json exists and has correct structure
-                assert "metadata.json" in tar.getnames()
-                metadata_file = tar.extractfile("metadata.json")
-                metadata = json.loads(metadata_file.read())
-                assert "created_at" in metadata
-                assert "datakult_version" in metadata
-                assert "django_version" in metadata
-                assert "database_engine" in metadata
+def test_empty_list(db):
+    """Returns 0 when given an empty list."""
+    deleted_count = delete_orphan_agents_by_ids([])
 
-                # Check database.json exists and contains media data
-                assert "database.json" in tar.getnames()
-                db_file = tar.extractfile("database.json")
-                db_data = json.loads(db_file.read())
-                media_entries = [entry for entry in db_data if entry["model"] == "core.media"]
-                assert len(media_entries) == 1
-                assert media_entries[0]["fields"]["title"] == "Test Media"
+    assert deleted_count == 0
 
-    def test_custom_filename_with_extension_handling(self, db):
-        """Custom filenames work correctly with automatic .tar.gz extension."""
-        with TemporaryDirectory() as tmpdir:
-            # Test with full extension
-            backup_path1 = create_backup(output_dir=Path(tmpdir), filename="custom_backup.tar.gz")
-            assert backup_path1.name == "custom_backup.tar.gz"
 
-            # Test without extension - should be added automatically
-            backup_path2 = create_backup(output_dir=Path(tmpdir), filename="custom")
-            assert backup_path2.name == "custom.tar.gz"
+def test_nonexistent_ids(db):
+    """Handles non-existent IDs gracefully."""
+    deleted_count = delete_orphan_agents_by_ids([99999, 88888])
 
-    def test_creates_output_directory(self, db):
-        """The output directory is created if it doesn't exist."""
-        with TemporaryDirectory() as tmpdir:
-            output_dir = Path(tmpdir) / "new_dir" / "backups"
-            backup_path = create_backup(output_dir=output_dir)
+    assert deleted_count == 0
 
-            assert output_dir.exists()
-            assert backup_path.exists()
+
+def test_handles_none_values(db):
+    """None values in the list are filtered out."""
+    orphan = Agent.objects.create(name="Orphan")
+
+    deleted_count = delete_orphan_agents_by_ids([None, orphan.pk, None])
+
+    assert deleted_count == 1
+
+
+def test_handles_duplicate_ids(db):
+    """Duplicate IDs are handled correctly."""
+    orphan = Agent.objects.create(name="Orphan")
+
+    deleted_count = delete_orphan_agents_by_ids([orphan.pk, orphan.pk, orphan.pk])
+
+    assert deleted_count == 1
+
+
+def test_returns_version_string():
+    """The function returns a version string."""
+    version = get_datakult_version()
+
+    assert isinstance(version, str)
+    assert version != ""
+
+
+def test_version_format_or_unknown():
+    """The version is either in semver format or 'unknown'."""
+    version = get_datakult_version()
+
+    # Should be either a version number (e.g., "0.1.0") or "unknown"
+    assert version == "unknown" or version[0].isdigit()
+
+
+def test_creates_complete_backup(db):
+    """A backup file is created with all expected content."""
+    # Create a media entry to verify data backup
+    Media.objects.create(title="Test Media", media_type="BOOK")
+
+    with TemporaryDirectory() as tmpdir:
+        backup_path = create_backup(output_dir=Path(tmpdir))
+
+        # Verify file creation
+        assert backup_path.exists()
+        assert backup_path.suffix == ".gz"
+        assert backup_path.name.startswith("datakult_backup_")
+
+        # Verify archive contents
+        with tarfile.open(backup_path, "r:gz") as tar:
+            # Check metadata.json exists and has correct structure
+            assert "metadata.json" in tar.getnames()
+            metadata_file = tar.extractfile("metadata.json")
+            metadata = json.loads(metadata_file.read())
+            assert "created_at" in metadata
+            assert "datakult_version" in metadata
+            assert "django_version" in metadata
+            assert "database_engine" in metadata
+
+            # Check database.json exists and contains media data
+            assert "database.json" in tar.getnames()
+            db_file = tar.extractfile("database.json")
+            db_data = json.loads(db_file.read())
+            media_entries = [entry for entry in db_data if entry["model"] == "core.media"]
+            assert len(media_entries) == 1
+            assert media_entries[0]["fields"]["title"] == "Test Media"
+
+
+def test_custom_filename_with_extension_handling(db):
+    """Custom filenames work correctly with automatic .tar.gz extension."""
+    with TemporaryDirectory() as tmpdir:
+        # Test with full extension
+        backup_path1 = create_backup(output_dir=Path(tmpdir), filename="custom_backup.tar.gz")
+        assert backup_path1.name == "custom_backup.tar.gz"
+
+        # Test without extension - should be added automatically
+        backup_path2 = create_backup(output_dir=Path(tmpdir), filename="custom")
+        assert backup_path2.name == "custom.tar.gz"
+
+
+def test_creates_output_directory(db):
+    """The output directory is created if it doesn't exist."""
+    with TemporaryDirectory() as tmpdir:
+        output_dir = Path(tmpdir) / "new_dir" / "backups"
+        backup_path = create_backup(output_dir=output_dir)
+
+        assert output_dir.exists()
+        assert backup_path.exists()

--- a/src/tests/core/test_views.py
+++ b/src/tests/core/test_views.py
@@ -15,1262 +15,1146 @@ from core.models import Agent, Media, SavedView
 from core.utils import create_backup
 
 
-class TestIndexView:
-    """Tests for the index (home) view."""
-
-    def test_index_accessible_when_logged_in(self, logged_in_client):
-        """The index view is accessible when logged in."""
-        response = logged_in_client.get(reverse("home"))
-
-        assert response.status_code == 200
-
-    def test_index_displays_media_list(self, logged_in_client, media):
-        """The index view displays the media list."""
-        response = logged_in_client.get(reverse("home"))
-
-        assert response.status_code == 200
-        assert "media_list" in response.context
-
-    def test_index_includes_saved_views_in_context(self, logged_in_client, user, db):
-        """The index view includes saved_views in the context for authenticated users."""
-        # Create some saved views for the user
-        SavedView.objects.create(user=user, name="View 1")
-        SavedView.objects.create(user=user, name="View 2")
-
-        response = logged_in_client.get(reverse("home"))
-
-        assert response.status_code == 200
-        assert "saved_views" in response.context
-        assert len(response.context["saved_views"]) == 2
-
-
-class TestMediaEditView:
-    """Tests for the media_edit view."""
-
-    def test_media_add_get_displays_form(self, logged_in_client):
-        """GET request displays the form."""
-        response = logged_in_client.get(reverse("media_add"))
-
-        assert response.status_code == 200
-        assert "form" in response.context
-
-    def test_media_add_post_creates_media(self, logged_in_client, db):
-        """POST with valid data creates a new media."""
-        data = {
-            "title": "New Test Media",
-            "media_type": "BOOK",
-            "status": "PLANNED",
-        }
-        response = logged_in_client.post(reverse("media_add"), data)
-
-        assert response.status_code == 302  # Redirect after success
-        assert Media.objects.filter(title="New Test Media").exists()
-
-    def test_media_add_shows_success_message(self, logged_in_client, db):
-        """Creating a new media shows a success message."""
-
-        data = {
-            "title": "New Test Media",
-            "media_type": "BOOK",
-            "status": "PLANNED",
-        }
-        response = logged_in_client.post(reverse("media_add"), data, follow=True)
-
-        messages = list(get_messages(response.wsgi_request))
-        assert len(messages) > 0
-        assert "New Test Media" in str(messages[0])
-        assert "created" in str(messages[0]).lower()
-
-    def test_media_add_with_new_contributor(self, logged_in_client, db):
-        """POST with new_contributors creates agents and links them."""
-        data = {
-            "title": "Book with Author",
-            "media_type": "BOOK",
-            "status": "PLANNED",
-            "new_contributors": ["New Author"],
-        }
-        response = logged_in_client.post(reverse("media_add"), data)
-
-        assert response.status_code == 302
-        media = Media.objects.get(title="Book with Author")
-        assert media.contributors.filter(name="New Author").exists()
-
-    def test_media_edit_get_displays_existing(self, logged_in_client, media):
-        """GET on edit view shows the existing media."""
-        response = logged_in_client.get(reverse("media_edit", kwargs={"pk": media.pk}))
-
-        assert response.status_code == 200
-        assert response.context["media"] == media
-
-    def test_media_edit_post_updates_media(self, logged_in_client, media):
-        """POST updates the existing media."""
-        data = {
-            "title": "Updated Title",
-            "media_type": media.media_type,
-            "status": "COMPLETED",
-        }
-        response = logged_in_client.post(
-            reverse("media_edit", kwargs={"pk": media.pk}),
-            data,
-        )
-
-        assert response.status_code == 302
-        media.refresh_from_db()
-        assert media.title == "Updated Title"
-        assert media.status == "COMPLETED"
-
-    def test_media_edit_shows_success_message(self, logged_in_client, media):
-        """Updating a media shows a success message."""
-
-        data = {
-            "title": "Updated Title",
-            "media_type": media.media_type,
-            "status": "COMPLETED",
-        }
-        response = logged_in_client.post(
-            reverse("media_edit", kwargs={"pk": media.pk}),
-            data,
-            follow=True,
-        )
-
-        messages = list(get_messages(response.wsgi_request))
-        assert len(messages) > 0
-        assert "Updated Title" in str(messages[0])
-        assert "updated" in str(messages[0]).lower()
+def test_index_accessible_when_logged_in(logged_in_client):
+    """The index view is accessible when logged in."""
+    response = logged_in_client.get(reverse("home"))
 
-    def test_media_edit_removes_contributor_cleans_orphan(self, logged_in_client, db):
-        """Removing a contributor from media deletes orphan agent."""
-        agent = Agent.objects.create(name="Soon Orphan")
-        media = Media.objects.create(title="Test", media_type="BOOK")
-        media.contributors.add(agent)
+    assert response.status_code == 200
 
-        data = {
-            "title": media.title,
-            "media_type": media.media_type,
-            "status": media.status,
-            "contributors": [],  # Remove the contributor
-        }
-        logged_in_client.post(reverse("media_edit", kwargs={"pk": media.pk}), data)
 
-        assert not Agent.objects.filter(pk=agent.pk).exists()
+def test_index_displays_media_list(logged_in_client, media):
+    """The index view displays the media list."""
+    response = logged_in_client.get(reverse("home"))
 
+    assert response.status_code == 200
+    assert "media_list" in response.context
+
+
+def test_index_includes_saved_views_in_context(logged_in_client, user, db):
+    """The index view includes saved_views in the context for authenticated users."""
+    SavedView.objects.create(user=user, name="View 1")
+    SavedView.objects.create(user=user, name="View 2")
+
+    response = logged_in_client.get(reverse("home"))
+
+    assert response.status_code == 200
+    assert "saved_views" in response.context
+    assert len(response.context["saved_views"]) == 2
+
+
+def test_media_add_get_displays_form(logged_in_client):
+    """GET request displays the form."""
+    response = logged_in_client.get(reverse("media_add"))
+
+    assert response.status_code == 200
+    assert "form" in response.context
+
+
+def test_media_add_post_creates_media(logged_in_client, db):
+    """POST with valid data creates a new media."""
+    data = {
+        "title": "New Test Media",
+        "media_type": "BOOK",
+        "status": "PLANNED",
+    }
+    response = logged_in_client.post(reverse("media_add"), data)
+
+    assert response.status_code == 302  # Redirect after success
+    assert Media.objects.filter(title="New Test Media").exists()
+
+
+def test_media_add_shows_success_message(logged_in_client, db):
+    """Creating a new media shows a success message."""
+    data = {
+        "title": "New Test Media",
+        "media_type": "BOOK",
+        "status": "PLANNED",
+    }
+    response = logged_in_client.post(reverse("media_add"), data, follow=True)
+
+    messages = list(get_messages(response.wsgi_request))
+    assert len(messages) > 0
+    assert "New Test Media" in str(messages[0])
+    assert "created" in str(messages[0]).lower()
+
+
+def test_media_add_with_new_contributor(logged_in_client, db):
+    """POST with new_contributors creates agents and links them."""
+    data = {
+        "title": "Book with Author",
+        "media_type": "BOOK",
+        "status": "PLANNED",
+        "new_contributors": ["New Author"],
+    }
+    response = logged_in_client.post(reverse("media_add"), data)
 
-class TestMediaDeleteView:
-    """Tests for the media_delete view."""
+    assert response.status_code == 302
+    media = Media.objects.get(title="Book with Author")
+    assert media.contributors.filter(name="New Author").exists()
 
-    def test_media_delete_post_deletes_media(self, logged_in_client, media):
-        """POST request deletes the media."""
-        media_pk = media.pk
-        response = logged_in_client.post(reverse("media_delete", kwargs={"pk": media_pk}))
 
-        assert response.status_code == 302
-        assert not Media.objects.filter(pk=media_pk).exists()
+def test_media_edit_get_displays_existing(logged_in_client, media):
+    """GET on edit view shows the existing media."""
+    response = logged_in_client.get(reverse("media_edit", kwargs={"pk": media.pk}))
+
+    assert response.status_code == 200
+    assert response.context["media"] == media
 
-    def test_media_delete_shows_success_message(self, logged_in_client, media):
-        """Deleting a media shows a success message with the title."""
 
-        media_title = media.title
-        response = logged_in_client.post(
-            reverse("media_delete", kwargs={"pk": media.pk}),
-            follow=True,
-        )
+def test_media_edit_post_updates_media(logged_in_client, media):
+    """POST updates the existing media."""
+    data = {
+        "title": "Updated Title",
+        "media_type": media.media_type,
+        "status": "COMPLETED",
+    }
+    response = logged_in_client.post(
+        reverse("media_edit", kwargs={"pk": media.pk}),
+        data,
+    )
 
-        messages = list(get_messages(response.wsgi_request))
-        assert len(messages) > 0
-        assert media_title in str(messages[0])
-        assert "deleted" in str(messages[0]).lower()
+    assert response.status_code == 302
+    media.refresh_from_db()
+    assert media.title == "Updated Title"
+    assert media.status == "COMPLETED"
 
-    def test_media_delete_cleans_orphan_contributors(self, logged_in_client, db):
-        """Deleting media removes orphan contributors."""
-        agent = Agent.objects.create(name="Will Be Orphan")
-        media = Media.objects.create(title="To Delete", media_type="BOOK")
-        media.contributors.add(agent)
 
-        logged_in_client.post(reverse("media_delete", kwargs={"pk": media.pk}))
+def test_media_edit_shows_success_message(logged_in_client, media):
+    """Updating a media shows a success message."""
+    data = {
+        "title": "Updated Title",
+        "media_type": media.media_type,
+        "status": "COMPLETED",
+    }
+    response = logged_in_client.post(
+        reverse("media_edit", kwargs={"pk": media.pk}),
+        data,
+        follow=True,
+    )
 
-        assert not Agent.objects.filter(pk=agent.pk).exists()
+    messages = list(get_messages(response.wsgi_request))
+    assert len(messages) > 0
+    assert "Updated Title" in str(messages[0])
+    assert "updated" in str(messages[0]).lower()
 
-    def test_media_delete_keeps_shared_contributors(self, logged_in_client, db):
-        """Contributors linked to other media are kept."""
-        agent = Agent.objects.create(name="Shared Author")
-        media1 = Media.objects.create(title="To Delete", media_type="BOOK")
-        media2 = Media.objects.create(title="To Keep", media_type="BOOK")
-        media1.contributors.add(agent)
-        media2.contributors.add(agent)
 
-        logged_in_client.post(reverse("media_delete", kwargs={"pk": media1.pk}))
+def test_media_edit_removes_contributor_cleans_orphan(logged_in_client, db):
+    """Removing a contributor from media deletes orphan agent."""
+    agent = Agent.objects.create(name="Soon Orphan")
+    media = Media.objects.create(title="Test", media_type="BOOK")
+    media.contributors.add(agent)
 
-        assert Agent.objects.filter(pk=agent.pk).exists()
+    data = {
+        "title": media.title,
+        "media_type": media.media_type,
+        "status": media.status,
+        "contributors": [],  # Remove the contributor
+    }
+    logged_in_client.post(reverse("media_edit", kwargs={"pk": media.pk}), data)
 
-    def test_media_delete_get_redirects(self, logged_in_client, media):
-        """GET request redirects to edit page (no delete)."""
-        response = logged_in_client.get(reverse("media_delete", kwargs={"pk": media.pk}))
+    assert not Agent.objects.filter(pk=agent.pk).exists()
 
-        assert response.status_code == 302
-        assert f"/media/{media.pk}/edit/" in response.url
-        assert Media.objects.filter(pk=media.pk).exists()
 
+def test_media_delete_post_deletes_media(logged_in_client, media):
+    """POST request deletes the media."""
+    media_pk = media.pk
+    response = logged_in_client.post(reverse("media_delete", kwargs={"pk": media_pk}))
 
-class TestSearchView:
-    """Tests for the search view (integrated into index view)."""
+    assert response.status_code == 302
+    assert not Media.objects.filter(pk=media_pk).exists()
 
-    def test_search_with_query(self, logged_in_client, media):
-        """Search returns results matching the query."""
-        response = logged_in_client.get(reverse("home"), {"search": media.title})
 
-        assert response.status_code == 200
+def test_media_delete_shows_success_message(logged_in_client, media):
+    """Deleting a media shows a success message with the title."""
+    media_title = media.title
+    response = logged_in_client.post(
+        reverse("media_delete", kwargs={"pk": media.pk}),
+        follow=True,
+    )
 
-    def test_search_by_title(self, logged_in_client, media_factory):
-        """Search finds media by title."""
-        media_factory(title="Unique Title Here")
-        media_factory(title="Other Book")
+    messages = list(get_messages(response.wsgi_request))
+    assert len(messages) > 0
+    assert media_title in str(messages[0])
+    assert "deleted" in str(messages[0]).lower()
 
-        response = logged_in_client.get(reverse("home"), {"search": "Unique"})
 
-        assert len(response.context["media_list"]) == 1
+def test_media_delete_cleans_orphan_contributors(logged_in_client, db):
+    """Deleting media removes orphan contributors."""
+    agent = Agent.objects.create(name="Will Be Orphan")
+    media = Media.objects.create(title="To Delete", media_type="BOOK")
+    media.contributors.add(agent)
 
-    def test_search_by_contributor(self, logged_in_client, db):
-        """Search finds media by contributor name."""
-        agent = Agent.objects.create(name="Famous Author")
-        media = Media.objects.create(title="Some Book", media_type="BOOK")
-        media.contributors.add(agent)
+    logged_in_client.post(reverse("media_delete", kwargs={"pk": media.pk}))
 
-        response = logged_in_client.get(reverse("home"), {"search": "Famous"})
+    assert not Agent.objects.filter(pk=agent.pk).exists()
 
-        assert media in response.context["media_list"]
 
+def test_media_delete_keeps_shared_contributors(logged_in_client, db):
+    """Contributors linked to other media are kept."""
+    agent = Agent.objects.create(name="Shared Author")
+    media1 = Media.objects.create(title="To Delete", media_type="BOOK")
+    media2 = Media.objects.create(title="To Keep", media_type="BOOK")
+    media1.contributors.add(agent)
+    media2.contributors.add(agent)
 
-class TestAgentSearchHtmxView:
-    """Tests for the agent_search_htmx view."""
+    logged_in_client.post(reverse("media_delete", kwargs={"pk": media1.pk}))
 
-    def test_agent_search_returns_matching_agents(self, logged_in_client, db):
-        """Search returns agents matching the query."""
-        Agent.objects.create(name="John Doe")
-        Agent.objects.create(name="Jane Doe")
-        Agent.objects.create(name="Bob Smith")
+    assert Agent.objects.filter(pk=agent.pk).exists()
 
-        response = logged_in_client.get(reverse("agent_search_htmx"), {"q": "Doe"})
 
-        assert response.status_code == 200
-        assert len(response.context["agents"]) == 2
+def test_media_delete_get_redirects(logged_in_client, media):
+    """GET request redirects to edit page (no delete)."""
+    response = logged_in_client.get(reverse("media_delete", kwargs={"pk": media.pk}))
 
-    def test_agent_search_empty_query(self, logged_in_client, agent):
-        """Empty query returns no agents."""
-        response = logged_in_client.get(reverse("agent_search_htmx"), {"q": ""})
+    assert response.status_code == 302
+    assert f"/media/{media.pk}/edit/" in response.url
+    assert Media.objects.filter(pk=media.pk).exists()
 
-        assert response.status_code == 200
-        assert len(response.context["agents"]) == 0
 
-    def test_agent_search_limits_results(self, logged_in_client, db):
-        """Search limits results to 12."""
-        for i in range(20):
-            Agent.objects.create(name=f"Agent {i}")
+def test_search_with_query(logged_in_client, media):
+    """Search returns results matching the query."""
+    response = logged_in_client.get(reverse("home"), {"search": media.title})
 
-        response = logged_in_client.get(reverse("agent_search_htmx"), {"q": "Agent"})
+    assert response.status_code == 200
 
-        assert len(response.context["agents"]) == 12
 
+def test_search_by_title(logged_in_client, media_factory):
+    """Search finds media by title."""
+    media_factory(title="Unique Title Here")
+    media_factory(title="Other Book")
 
-class TestAgentSelectHtmxView:
-    """Tests for the agent_select_htmx view."""
+    response = logged_in_client.get(reverse("home"), {"search": "Unique"})
 
-    def test_agent_select_returns_chip(self, logged_in_client, agent):
-        """Selecting an agent returns the chip template."""
-        response = logged_in_client.post(
-            reverse("agent_select_htmx"),
-            {"id": agent.pk},
-        )
+    assert len(response.context["media_list"]) == 1
 
-        assert response.status_code == 200
-        assert response.context["agent"] == agent
 
-    def test_agent_select_nonexistent(self, logged_in_client, db):
-        """Selecting a non-existent agent returns error."""
-        response = logged_in_client.post(
-            reverse("agent_select_htmx"),
-            {"id": 99999},
-        )
+def test_search_by_contributor(logged_in_client, db):
+    """Search finds media by contributor name."""
+    agent = Agent.objects.create(name="Famous Author")
+    media = Media.objects.create(title="Some Book", media_type="BOOK")
+    media.contributors.add(agent)
 
-        assert response.status_code == 200
-        assert response.context["error"] == "Agent not found"
+    response = logged_in_client.get(reverse("home"), {"search": "Famous"})
 
+    assert media in response.context["media_list"]
 
-class TestSortingHelper:
-    """Tests for the _resolve_sorting helper logic via index view."""
 
-    def test_default_sorting(self, logged_in_client):
-        """Default sorting is by review_date descending."""
-        response = logged_in_client.get(reverse("home"))
+def test_agent_search_returns_matching_agents(logged_in_client, db):
+    """Search returns agents matching the query."""
+    Agent.objects.create(name="John Doe")
+    Agent.objects.create(name="Jane Doe")
+    Agent.objects.create(name="Bob Smith")
 
-        assert response.context["sort_field"] == "review_date"
-        assert response.context["sort"] == "-review_date"
+    response = logged_in_client.get(reverse("agent_search_htmx"), {"q": "Doe"})
 
-    def test_custom_sorting(self, logged_in_client):
-        """Custom sorting is applied."""
-        response = logged_in_client.get(reverse("home"), {"sort": "score"})
+    assert response.status_code == 200
+    assert len(response.context["agents"]) == 2
 
-        assert response.context["sort_field"] == "score"
-        assert response.context["sort"] == "score"
 
-    def test_descending_sorting(self, logged_in_client):
-        """Descending sorting is applied."""
-        response = logged_in_client.get(reverse("home"), {"sort": "-review_date"})
+def test_agent_search_empty_query(logged_in_client, agent):
+    """Empty query returns no agents."""
+    response = logged_in_client.get(reverse("agent_search_htmx"), {"q": ""})
 
-        assert response.context["sort_field"] == "review_date"
-        assert response.context["sort"] == "-review_date"
+    assert response.status_code == 200
+    assert len(response.context["agents"]) == 0
 
-    def test_invalid_sort_field_uses_default(self, logged_in_client):
-        """Invalid sort field falls back to default."""
-        response = logged_in_client.get(reverse("home"), {"sort": "invalid_field"})
 
-        assert response.context["sort_field"] == "review_date"
+def test_agent_search_limits_results(logged_in_client, db):
+    """Search limits results to 12."""
+    for i in range(20):
+        Agent.objects.create(name=f"Agent {i}")
 
-    def test_sorting_by_updated_at(self, logged_in_client):
-        """Sorting by updated_at field works correctly."""
-        response = logged_in_client.get(reverse("home"), {"sort": "updated_at"})
+    response = logged_in_client.get(reverse("agent_search_htmx"), {"q": "Agent"})
 
-        assert response.context["sort_field"] == "updated_at"
-        assert response.context["sort"] == "updated_at"
+    assert len(response.context["agents"]) == 12
 
-    def test_sorting_by_updated_at_descending(self, logged_in_client):
-        """Descending sorting by updated_at field works correctly."""
-        response = logged_in_client.get(reverse("home"), {"sort": "-updated_at"})
 
-        assert response.context["sort_field"] == "updated_at"
-        assert response.context["sort"] == "-updated_at"
+def test_agent_select_returns_chip(logged_in_client, agent):
+    """Selecting an agent returns the chip template."""
+    response = logged_in_client.post(
+        reverse("agent_select_htmx"),
+        {"id": agent.pk},
+    )
 
+    assert response.status_code == 200
+    assert response.context["agent"] == agent
 
-class TestFilteringHelper:
-    """Tests for the filtering logic via index view."""
 
-    def test_filter_by_type(self, logged_in_client, media_factory):
-        """Filtering by media type works."""
-        media_factory(title="A Book", media_type="BOOK")
-        media_factory(title="A Film", media_type="FILM")
+def test_agent_select_nonexistent(logged_in_client, db):
+    """Selecting a non-existent agent returns error."""
+    response = logged_in_client.post(
+        reverse("agent_select_htmx"),
+        {"id": 99999},
+    )
 
-        response = logged_in_client.get(reverse("home"), {"type": "BOOK"})
+    assert response.status_code == 200
+    assert response.context["error"] == "Agent not found"
 
-        titles = [m.title for m in response.context["media_list"]]
-        assert "A Book" in titles
-        assert "A Film" not in titles
 
-    def test_filter_by_status(self, logged_in_client, media_factory):
-        """Filtering by status works."""
-        media_factory(title="Planned", status="PLANNED")
-        media_factory(title="Completed", status="COMPLETED")
+def test_default_sorting(logged_in_client):
+    """Default sorting is by review_date descending."""
+    response = logged_in_client.get(reverse("home"))
 
-        response = logged_in_client.get(reverse("home"), {"status": "COMPLETED"})
+    assert response.context["sort_field"] == "review_date"
+    assert response.context["sort"] == "-review_date"
 
-        titles = [m.title for m in response.context["media_list"]]
-        assert "Completed" in titles
-        assert "Planned" not in titles
 
-    def test_filter_by_contributor(self, logged_in_client, db):
-        """Filtering by contributor works."""
-        agent = Agent.objects.create(name="Specific Author")
-        media = Media.objects.create(title="By Author", media_type="BOOK")
-        media.contributors.add(agent)
-        Media.objects.create(title="No Author", media_type="BOOK")
+def test_custom_sorting(logged_in_client):
+    """Custom sorting is applied."""
+    response = logged_in_client.get(reverse("home"), {"sort": "score"})
 
-        response = logged_in_client.get(reverse("home"), {"contributor": agent.pk})
+    assert response.context["sort_field"] == "score"
+    assert response.context["sort"] == "score"
 
-        titles = [m.title for m in response.context["media_list"]]
-        assert "By Author" in titles
-        assert "No Author" not in titles
 
-    def test_filter_by_no_score(self, logged_in_client, media_factory):
-        """Filtering by 'no score' works."""
-        media_factory(title="Rated", score=8)
-        media_factory(title="Unrated", score=None)
-
-        response = logged_in_client.get(reverse("home"), {"score": "none"})
-
-        titles = [m.title for m in response.context["media_list"]]
-        assert "Unrated" in titles
-        assert "Rated" not in titles
-
-    def test_filter_with_invalid_date_ignores_filter(self, logged_in_client, media_factory):
-        """Invalid date values in URL are silently ignored."""
-        media_factory(title="Recent", review_date="2025-01-01")
-        media_factory(title="Old", review_date="2020-01-01")
-
-        # Try with invalid date format - should not crash and return all results
-        response = logged_in_client.get(reverse("home"), {"review_from": "not-a-date"})
-
-        assert response.status_code == 200
-        titles = [m.title for m in response.context["media_list"]]
-        # Both should be present since the invalid filter was ignored
-        assert "Recent" in titles
-        assert "Old" in titles
+def test_descending_sorting(logged_in_client):
+    """Descending sorting is applied."""
+    response = logged_in_client.get(reverse("home"), {"sort": "-review_date"})
 
+    assert response.context["sort_field"] == "review_date"
+    assert response.context["sort"] == "-review_date"
 
-class TestMediaReviewHtmxViews:
-    """Tests for HTMX views that display media reviews."""
 
-    def test_media_review_clamped_returns_partial(self, logged_in_client, db):
-        """Clamped review view returns the clamped partial template."""
-        media = Media.objects.create(
-            title="Test Media",
-            media_type="BOOK",
-            review="This is a test review with some content that could be truncated.",
-        )
-        response = logged_in_client.get(reverse("media_review_clamped_htmx", kwargs={"pk": media.pk}))
+def test_invalid_sort_field_uses_default(logged_in_client):
+    """Invalid sort field falls back to default."""
+    response = logged_in_client.get(reverse("home"), {"sort": "invalid_field"})
 
-        assert response.status_code == 200
-        assert "partials/media_items/media_review_clamped.html" in [t.name for t in response.templates]
-        assert "media" in response.context
-        assert response.context["media"] == media
+    assert response.context["sort_field"] == "review_date"
 
-    def test_media_review_clamped_with_short_review(self, logged_in_client, db):
-        """Clamped review with short text doesn't show 'See more' button."""
-        media = Media.objects.create(
-            title="Test Media",
-            media_type="BOOK",
-            review="Short review",
-        )
-        response = logged_in_client.get(reverse("media_review_clamped_htmx", kwargs={"pk": media.pk}))
 
-        content = response.content.decode("utf-8")
-        # With less than 50 words, the 'See more' button should not appear
-        assert "See more" not in content
+def test_sorting_by_updated_at(logged_in_client):
+    """Sorting by updated_at field works correctly."""
+    response = logged_in_client.get(reverse("home"), {"sort": "updated_at"})
 
-    def test_media_review_clamped_with_long_review(self, logged_in_client, db):
-        """Clamped review with long text shows 'See more' button."""
-        long_review = " ".join(["word"] * 55)
-        media = Media.objects.create(
-            title="Test Media",
-            media_type="BOOK",
-            review=long_review,
-        )
-        response = logged_in_client.get(reverse("media_review_clamped_htmx", kwargs={"pk": media.pk}))
+    assert response.context["sort_field"] == "updated_at"
+    assert response.context["sort"] == "updated_at"
 
-        content = response.content.decode("utf-8")
-        # With more than 50 words, the 'See more' button should appear
-        assert "See more" in content
 
-    def test_media_review_full_returns_partial(self, logged_in_client, db):
-        """Full review view returns the full partial template."""
-        media = Media.objects.create(
-            title="Test Media",
-            media_type="BOOK",
-            review="This is a test review.",
-        )
-        response = logged_in_client.get(reverse("media_review_full_htmx", kwargs={"pk": media.pk}))
+def test_sorting_by_updated_at_descending(logged_in_client):
+    """Descending sorting by updated_at field works correctly."""
+    response = logged_in_client.get(reverse("home"), {"sort": "-updated_at"})
 
-        assert response.status_code == 200
-        assert "partials/media_items/media_review_full.html" in [t.name for t in response.templates]
-        assert "media" in response.context
-        assert response.context["media"] == media
+    assert response.context["sort_field"] == "updated_at"
+    assert response.context["sort"] == "-updated_at"
 
-    def test_media_review_full_shows_see_less_button(self, logged_in_client, db):
-        """Full review view shows 'See less' button."""
-        media = Media.objects.create(
-            title="Test Media",
-            media_type="BOOK",
-            review="Some review content",
-        )
-        response = logged_in_client.get(reverse("media_review_full_htmx", kwargs={"pk": media.pk}))
 
-        content = response.content.decode("utf-8")
-        assert "See less" in content
+def test_filter_by_type(logged_in_client, media_factory):
+    """Filtering by media type works."""
+    media_factory(title="A Book", media_type="BOOK")
+    media_factory(title="A Film", media_type="FILM")
 
-    def test_media_review_renders_html_safely(self, logged_in_client, db):
-        """Review views render HTML content from review_rendered field."""
-        media = Media.objects.create(
-            title="Test Media",
-            media_type="BOOK",
-            review="**Bold text**",
-        )
-        # After save, review_rendered should contain HTML
-        media.refresh_from_db()
+    response = logged_in_client.get(reverse("home"), {"type": "BOOK"})
 
-        response = logged_in_client.get(reverse("media_review_full_htmx", kwargs={"pk": media.pk}))
-        content = response.content.decode("utf-8")
+    titles = [m.title for m in response.context["media_list"]]
+    assert "A Book" in titles
+    assert "A Film" not in titles
 
-        # The rendered HTML should be present in the response
-        assert "<strong>Bold text</strong>" in content
 
-    def test_media_review_nonexistent_media_returns_404(self, logged_in_client):
-        """Accessing review views with nonexistent media returns 404."""
-        response_clamped = logged_in_client.get(reverse("media_review_clamped_htmx", kwargs={"pk": 99999}))
-        response_full = logged_in_client.get(reverse("media_review_full_htmx", kwargs={"pk": 99999}))
+def test_filter_by_status(logged_in_client, media_factory):
+    """Filtering by status works."""
+    media_factory(title="Planned", status="PLANNED")
+    media_factory(title="Completed", status="COMPLETED")
 
-        assert response_clamped.status_code == 404
-        assert response_full.status_code == 404
+    response = logged_in_client.get(reverse("home"), {"status": "COMPLETED"})
 
+    titles = [m.title for m in response.context["media_list"]]
+    assert "Completed" in titles
+    assert "Planned" not in titles
 
-class TestBackupManageView:
-    """Tests for the backup_manage view."""
 
-    def test_backup_manage_displays_page(self, logged_in_client):
-        """The backup manage view displays the backup management page."""
-        response = logged_in_client.get(reverse("backup_manage"))
+def test_filter_by_contributor(logged_in_client, db):
+    """Filtering by contributor works."""
+    agent = Agent.objects.create(name="Specific Author")
+    media = Media.objects.create(title="By Author", media_type="BOOK")
+    media.contributors.add(agent)
+    Media.objects.create(title="No Author", media_type="BOOK")
 
-        assert response.status_code == 200
-        assert "base/backup_manage.html" in [t.name for t in response.templates]
+    response = logged_in_client.get(reverse("home"), {"contributor": agent.pk})
 
+    titles = [m.title for m in response.context["media_list"]]
+    assert "By Author" in titles
+    assert "No Author" not in titles
 
-class TestBackupExportView:
-    """Tests for the backup_export view."""
 
-    def test_backup_export_creates_and_downloads_backup(self, logged_in_client, db):
-        """The backup export view creates and returns a backup file."""
-        # Create some test data
-        Media.objects.create(title="Test Media", media_type="BOOK")
+def test_filter_by_no_score(logged_in_client, media_factory):
+    """Filtering by 'no score' works."""
+    media_factory(title="Rated", score=8)
+    media_factory(title="Unrated", score=None)
 
-        response = logged_in_client.get(reverse("backup_export"))
+    response = logged_in_client.get(reverse("home"), {"score": "none"})
 
-        # Should return a file download
-        assert response.status_code == 200
-        # Django's FileResponse detects .tar.gz as gzip
-        assert response["Content-Type"] == "application/gzip"
-        assert "attachment" in response["Content-Disposition"]
-        assert "datakult_backup_" in response["Content-Disposition"]
+    titles = [m.title for m in response.context["media_list"]]
+    assert "Unrated" in titles
+    assert "Rated" not in titles
 
-    def test_backup_export_handles_errors_gracefully(self, logged_in_client, monkeypatch):
-        """The backup export view handles errors and redirects with message."""
 
-        # Mock create_backup to raise an exception
-        def mock_create_backup(*args, **kwargs):
-            msg = "Test error"
-            raise OSError(msg)
+def test_filter_with_invalid_date_ignores_filter(logged_in_client, media_factory):
+    """Invalid date values in URL are silently ignored."""
+    media_factory(title="Recent", review_date="2025-01-01")
+    media_factory(title="Old", review_date="2020-01-01")
 
-        monkeypatch.setattr("core.views.create_backup", mock_create_backup)
+    # Try with invalid date format - should not crash and return all results
+    response = logged_in_client.get(reverse("home"), {"review_from": "not-a-date"})
 
-        response = logged_in_client.get(reverse("backup_export"))
+    assert response.status_code == 200
+    titles = [m.title for m in response.context["media_list"]]
+    # Both should be present since the invalid filter was ignored
+    assert "Recent" in titles
+    assert "Old" in titles
 
-        # Should redirect back to backup manage with error message
-        assert response.status_code == 302
-        assert response.url == reverse("backup_manage")
 
+def test_media_review_clamped_returns_partial(logged_in_client, db):
+    """Clamped review view returns the clamped partial template."""
+    media = Media.objects.create(
+        title="Test Media",
+        media_type="BOOK",
+        review="This is a test review with some content that could be truncated.",
+    )
+    response = logged_in_client.get(reverse("media_review_clamped_htmx", kwargs={"pk": media.pk}))
 
-class TestBackupImportView:
-    """Tests for the backup_import view."""
+    assert response.status_code == 200
+    assert "partials/media_items/media_review_clamped.html" in [t.name for t in response.templates]
+    assert "media" in response.context
+    assert response.context["media"] == media
 
-    def test_backup_import_get_redirects(self, logged_in_client):
-        """GET requests to backup import redirect to backup manage."""
-        response = logged_in_client.get(reverse("backup_import"))
 
-        assert response.status_code == 302
-        assert response.url == reverse("backup_manage")
+def test_media_review_clamped_with_short_review(logged_in_client, db):
+    """Clamped review with short text doesn't show 'See more' button."""
+    media = Media.objects.create(
+        title="Test Media",
+        media_type="BOOK",
+        review="Short review",
+    )
+    response = logged_in_client.get(reverse("media_review_clamped_htmx", kwargs={"pk": media.pk}))
 
-    def test_backup_import_requires_file(self, logged_in_client):
-        """The backup import view requires a file to be uploaded."""
-        response = logged_in_client.post(reverse("backup_import"))
+    content = response.content.decode("utf-8")
+    # With less than 50 words, the 'See more' button should not appear
+    assert "See more" not in content
 
-        assert response.status_code == 302
-        # Should redirect back with error message
 
-    def test_backup_import_rejects_invalid_format(self, logged_in_client):
-        """The backup import view rejects files with invalid format."""
-        invalid_file = SimpleUploadedFile("backup.txt", b"not a backup", content_type="text/plain")
+def test_media_review_clamped_with_long_review(logged_in_client, db):
+    """Clamped review with long text shows 'See more' button."""
+    long_review = " ".join(["word"] * 55)
+    media = Media.objects.create(
+        title="Test Media",
+        media_type="BOOK",
+        review=long_review,
+    )
+    response = logged_in_client.get(reverse("media_review_clamped_htmx", kwargs={"pk": media.pk}))
 
-        response = logged_in_client.post(reverse("backup_import"), {"backup_file": invalid_file})
+    content = response.content.decode("utf-8")
+    # With more than 50 words, the 'See more' button should appear
+    assert "See more" in content
 
-        assert response.status_code == 302
-        assert response.url == reverse("backup_manage")
 
-    def test_backup_import_restores_data(self, logged_in_client, db):
-        """The backup import view successfully restores data from a backup."""
-        # Create test data and backup
-        original_media = Media.objects.create(title="Original Media", media_type="BOOK", status="COMPLETED")
+def test_media_review_full_returns_partial(logged_in_client, db):
+    """Full review view returns the full partial template."""
+    media = Media.objects.create(
+        title="Test Media",
+        media_type="BOOK",
+        review="This is a test review.",
+    )
+    response = logged_in_client.get(reverse("media_review_full_htmx", kwargs={"pk": media.pk}))
 
-        with TemporaryDirectory() as tmpdir:
-            # Create a backup
-            backup_path = create_backup(output_dir=Path(tmpdir))
+    assert response.status_code == 200
+    assert "partials/media_items/media_review_full.html" in [t.name for t in response.templates]
+    assert "media" in response.context
+    assert response.context["media"] == media
 
-            # Clear the database
-            Media.objects.all().delete()
-            assert Media.objects.count() == 0
 
-            # Import the backup via the view
-            with backup_path.open("rb") as backup_file:
-                uploaded_file = SimpleUploadedFile(
-                    backup_path.name, backup_file.read(), content_type="application/x-tar"
-                )
-                response = logged_in_client.post(reverse("backup_import"), {"backup_file": uploaded_file})
+def test_media_review_full_shows_see_less_button(logged_in_client, db):
+    """Full review view shows 'See less' button."""
+    media = Media.objects.create(
+        title="Test Media",
+        media_type="BOOK",
+        review="Some review content",
+    )
+    response = logged_in_client.get(reverse("media_review_full_htmx", kwargs={"pk": media.pk}))
 
-            # Should redirect to home
-            assert response.status_code == 302
-            assert response.url == reverse("home")
+    content = response.content.decode("utf-8")
+    assert "See less" in content
 
-            # Data should be restored
-            assert Media.objects.count() == 1
-            restored_media = Media.objects.first()
-            assert restored_media.title == original_media.title
-            assert restored_media.status == original_media.status
 
-    def test_backup_import_handles_errors(self, logged_in_client):
-        """The backup import view handles errors gracefully."""
-        # Create a valid tar.gz file with invalid content
-        invalid_file = SimpleUploadedFile("backup.tar.gz", b"invalid content", content_type="application/x-tar")
+def test_media_review_renders_html_safely(logged_in_client, db):
+    """Review views render HTML content from review_rendered field."""
+    media = Media.objects.create(
+        title="Test Media",
+        media_type="BOOK",
+        review="**Bold text**",
+    )
+    # After save, review_rendered should contain HTML
+    media.refresh_from_db()
 
-        response = logged_in_client.post(reverse("backup_import"), {"backup_file": invalid_file})
+    response = logged_in_client.get(reverse("media_review_full_htmx", kwargs={"pk": media.pk}))
+    content = response.content.decode("utf-8")
 
-        # Should redirect back to backup manage with error message
-        assert response.status_code == 302
-        assert response.url == reverse("backup_manage")
+    # The rendered HTML should be present in the response
+    assert "<strong>Bold text</strong>" in content
 
 
-class TestPaginationBehavior:
-    """Tests for pagination behavior across views."""
+def test_media_review_nonexistent_media_returns_404(logged_in_client):
+    """Accessing review views with nonexistent media returns 404."""
+    response_clamped = logged_in_client.get(reverse("media_review_clamped_htmx", kwargs={"pk": 99999}))
+    response_full = logged_in_client.get(reverse("media_review_full_htmx", kwargs={"pk": 99999}))
 
-    def test_index_paginates_results_across_pages(self, logged_in_client, media_factory):
-        """Index view paginates results with 20 items per page and navigates correctly."""
-        # Create 25 media items
-        for i in range(25):
-            media_factory(title=f"Media {i}")
+    assert response_clamped.status_code == 404
+    assert response_full.status_code == 404
 
-        # Test first page
-        response_page1 = logged_in_client.get(reverse("home"))
-        assert response_page1.status_code == 200
-        assert "page_obj" in response_page1.context
-        assert len(response_page1.context["media_list"]) == 20
-        assert response_page1.context["page_obj"].has_next()
 
-        # Test second page
-        response_page2 = logged_in_client.get(reverse("home"), {"page": 2})
-        assert response_page2.status_code == 200
-        assert len(response_page2.context["media_list"]) == 5
-        assert response_page2.context["page_obj"].has_previous()
-        assert not response_page2.context["page_obj"].has_next()
+def test_backup_manage_displays_page(logged_in_client):
+    """The backup manage view displays the backup management page."""
+    response = logged_in_client.get(reverse("backup_manage"))
 
-    def test_search_paginates_results(self, logged_in_client, media_factory):
-        """Search view paginates results."""
-        # Create 25 media items with searchable title
-        for i in range(25):
-            media_factory(title=f"Searchable {i}")
+    assert response.status_code == 200
+    assert "base/backup_manage.html" in [t.name for t in response.templates]
 
-        response = logged_in_client.get(reverse("home"), {"search": "Searchable"})
 
-        assert response.status_code == 200
-        assert len(response.context["media_list"]) == 20
-        assert response.context["page_obj"].has_next()
+def test_backup_export_creates_and_downloads_backup(logged_in_client, db):
+    """The backup export view creates and returns a backup file."""
+    # Create some test data
+    Media.objects.create(title="Test Media", media_type="BOOK")
 
+    response = logged_in_client.get(reverse("backup_export"))
 
-class TestLoadMoreMediaView:
-    """Tests for the load_more_media view (infinite scroll / lazy-loading)."""
+    # Should return a file download
+    assert response.status_code == 200
+    # Django's FileResponse detects .tar.gz as gzip
+    assert response["Content-Type"] == "application/gzip"
+    assert "attachment" in response["Content-Disposition"]
+    assert "datakult_backup_" in response["Content-Disposition"]
 
-    def test_load_more_returns_partial_template(self, logged_in_client, media_factory):
-        """Load more view returns the media-items-page partial template."""
-        for i in range(25):
-            media_factory(title=f"Media {i}")
 
-        response = logged_in_client.get(reverse("load_more_media"), {"page": 2})
+def test_backup_export_handles_errors_gracefully(logged_in_client, monkeypatch):
+    """The backup export view handles errors and redirects with message."""
 
-        assert response.status_code == 200
-        assert "partials/media_items/media_list_page.html" in [t.name for t in response.templates]
+    def mock_create_backup(*args, **kwargs):
+        msg = "Test error"
+        raise OSError(msg)
 
-    def test_load_more_returns_next_page_items(self, logged_in_client, media_factory):
-        """Load more view returns items for the requested page."""
-        # Create 25 items
-        for i in range(25):
-            media_factory(title=f"Media {i:02d}")
+    monkeypatch.setattr("core.views.create_backup", mock_create_backup)
 
-        # Request page 2 (items 21-25)
-        response = logged_in_client.get(reverse("load_more_media"), {"page": 2})
+    response = logged_in_client.get(reverse("backup_export"))
 
-        assert response.status_code == 200
-        assert len(response.context["media_list"]) == 5
+    # Should redirect back to backup manage with error message
+    assert response.status_code == 302
+    assert response.url == reverse("backup_manage")
 
-    def test_load_more_preserves_sorting(self, logged_in_client, media_factory):
-        """Load more view preserves sort order from initial request."""
-        media_factory(title="A", score=5)
-        media_factory(title="B", score=8)
-        media_factory(title="C", score=3)
 
-        response = logged_in_client.get(reverse("load_more_media"), {"page": 1, "sort": "score"})
+def test_backup_import_get_redirects(logged_in_client):
+    """GET requests to backup import redirect to backup manage."""
+    response = logged_in_client.get(reverse("backup_import"))
 
-        assert response.status_code == 200
-        scores = [m.score for m in response.context["media_list"] if m.score is not None]
-        # Should be sorted ascending by score
-        assert scores == sorted(scores)
+    assert response.status_code == 302
+    assert response.url == reverse("backup_manage")
 
-    def test_load_more_preserves_filters(self, logged_in_client, media_factory):
-        """Load more view preserves filters from initial request."""
-        media_factory(title="Book 1", media_type="BOOK")
-        media_factory(title="Film 1", media_type="FILM")
-        media_factory(title="Book 2", media_type="BOOK")
 
-        response = logged_in_client.get(reverse("load_more_media"), {"page": 1, "type": "BOOK"})
+def test_backup_import_requires_file(logged_in_client):
+    """The backup import view requires a file to be uploaded."""
+    response = logged_in_client.post(reverse("backup_import"))
 
-        assert response.status_code == 200
-        media_types = [m.media_type for m in response.context["media_list"]]
-        assert all(mt == "BOOK" for mt in media_types)
+    assert response.status_code == 302
+    # Should redirect back with error message
 
-    def test_load_more_with_search_query(self, logged_in_client, media_factory):
-        """Load more view applies search query when provided."""
-        media_factory(title="Python Guide")
-        media_factory(title="JavaScript Guide")
-        media_factory(title="Python Cookbook")
 
-        response = logged_in_client.get(reverse("load_more_media"), {"page": 1, "search": "Python"})
+def test_backup_import_rejects_invalid_format(logged_in_client):
+    """The backup import view rejects files with invalid format."""
+    invalid_file = SimpleUploadedFile("backup.txt", b"not a backup", content_type="text/plain")
 
-        assert response.status_code == 200
-        assert len(response.context["media_list"]) == 2
-        titles = [m.title for m in response.context["media_list"]]
-        assert all("Python" in title for title in titles)
+    response = logged_in_client.post(reverse("backup_import"), {"backup_file": invalid_file})
 
-    def test_load_more_page_obj_pagination_state(self, logged_in_client, media_factory):
-        """Load more view sets has_next correctly across different page states."""
-        # Create 45 items (3 pages of 20 items each)
-        for i in range(45):
-            media_factory(title=f"Media {i}")
-
-        # Test page 2 (middle page) - should have next
-        response_page2 = logged_in_client.get(reverse("load_more_media"), {"page": 2})
-        assert response_page2.status_code == 200
-        assert response_page2.context["page_obj"].has_next()
-        assert response_page2.context["page_obj"].number == 2
-
-        # Test page 3 (last page) - should not have next
-        response_page3 = logged_in_client.get(reverse("load_more_media"), {"page": 3})
-        assert response_page3.status_code == 200
-        assert not response_page3.context["page_obj"].has_next()
-        assert response_page3.context["page_obj"].number == 3
-
-    def test_load_more_includes_view_mode_in_context(self, logged_in_client, media_factory):
-        """Load more view includes view_mode in context for template rendering."""
-        media_factory(title="Test")
-
-        response_default = logged_in_client.get(reverse("load_more_media"), {"page": 1})
-        response_list = logged_in_client.get(reverse("load_more_media"), {"page": 1, "view_mode": "list"})
-        response_grid = logged_in_client.get(reverse("load_more_media"), {"page": 1, "view_mode": "grid"})
-
-        assert response_default.context["view_mode"] == "grid"
-        assert response_list.context["view_mode"] == "list"
-        assert response_grid.context["view_mode"] == "grid"
-
-
-class TestMediaDetailView:
-    """Tests for the media_detail view."""
-
-    def test_media_detail_accessible_when_logged_in(self, logged_in_client, media):
-        """The detail view is accessible when logged in."""
-        response = logged_in_client.get(reverse("media_detail", kwargs={"pk": media.pk}))
-
-        assert response.status_code == 200
-        assert response.context["media"] == media
-
-    def test_media_detail_displays_correct_template(self, logged_in_client, media):
-        """The detail view uses the media_detail template."""
-        response = logged_in_client.get(reverse("media_detail", kwargs={"pk": media.pk}))
-
-        assert response.status_code == 200
-        assert "base/media_detail.html" in [t.name for t in response.templates]
-
-    def test_media_detail_nonexistent_returns_404(self, logged_in_client):
-        """Accessing detail view with nonexistent media returns 404."""
-        response = logged_in_client.get(reverse("media_detail", kwargs={"pk": 99999}))
-
-        assert response.status_code == 404
-
-    def test_media_detail_shows_all_fields(self, logged_in_client, db):
-        """The detail view displays all media fields."""
-        agent = Agent.objects.create(name="Test Author")
-        media = Media.objects.create(
-            title="Complete Media",
-            media_type="BOOK",
-            status="COMPLETED",
-            score=8,
-            review="This is a detailed review.",
-            pub_year=2023,
-            external_uri="https://example.com",
-        )
-        media.contributors.add(agent)
-
-        response = logged_in_client.get(reverse("media_detail", kwargs={"pk": media.pk}))
-        content = response.content.decode("utf-8")
-
-        assert media.title in content
-        assert "2023" in content
-        assert agent.name in content
-        assert "https://example.com" in content
-
-    def test_media_detail_contributor_links_to_filtered_list(self, logged_in_client, db):
-        """Contributor links in detail view navigate to filtered home page."""
-        agent = Agent.objects.create(name="Test Contributor")
-        media = Media.objects.create(
-            title="Test Media",
-            media_type="BOOK",
-        )
-        media.contributors.add(agent)
-
-        response = logged_in_client.get(reverse("media_detail", kwargs={"pk": media.pk}))
-        content = response.content.decode("utf-8")
-
-        # Should contain a link to home with contributor filter
-        assert f"contributor={agent.id}" in content
-        assert 'class="link link-hover contributor-link"' in content
-        # Should NOT contain HTMX attributes for contributor links
-        assert "hx-target" not in content
-
-
-class TestSavedViewSaveView:
-    """Tests for the saved_view_save view."""
-
-    def test_saved_view_save_creates_new_view(self, logged_in_client, user, db):
-        """POST with valid data creates a new saved view."""
-        data = {
-            "view_name": "My Books",
-            "type": ["BOOK"],
-            "status": ["COMPLETED"],
-            "score": ["8", "9"],
-            "sort": "-score",
-            "view_mode": "list",
-        }
-        response = logged_in_client.post(reverse("saved_view_save"), data)
-
-        # Should redirect to home with filters applied
-        assert response.status_code == 302
-        assert "/" in response.url
-
-        # View should be created in database
-        assert SavedView.objects.filter(user=user, name="My Books").exists()
-        saved_view = SavedView.objects.get(user=user, name="My Books")
-        assert saved_view.filter_types == ["BOOK"]
-        assert saved_view.filter_statuses == ["COMPLETED"]
-        assert saved_view.filter_scores == ["8", "9"]
-        assert saved_view.sort == "-score"
-        assert saved_view.view_mode == "list"
-
-    def test_saved_view_save_updates_existing_view(self, logged_in_client, user, db):
-        """POST with existing view name updates the view instead of creating duplicate."""
-        # Create initial view
-        SavedView.objects.create(
-            user=user,
-            name="My View",
-            filter_types=["BOOK"],
-            sort="-review_date",
-        )
-
-        # Update with different filters
-        data = {
-            "view_name": "My View",
-            "type": ["FILM"],
-            "sort": "-score",
-            "view_mode": "grid",
-        }
-        response = logged_in_client.post(reverse("saved_view_save"), data)
-
-        assert response.status_code == 302
-
-        # Should still be only one view with that name
-        assert SavedView.objects.filter(user=user, name="My View").count() == 1
-
-        # View should be updated
-        saved_view = SavedView.objects.get(user=user, name="My View")
-        assert saved_view.filter_types == ["FILM"]
-        assert saved_view.sort == "-score"
-        assert saved_view.view_mode == "grid"
-
-    def test_saved_view_save_requires_view_name(self, logged_in_client, user, db):
-        """POST without view_name redirects with error message."""
-        data = {
-            "type": ["BOOK"],
-        }
-        response = logged_in_client.post(reverse("saved_view_save"), data)
-
-        # Should redirect back to home
-        assert response.status_code == 302
-
-        # No view should be created
-        assert SavedView.objects.filter(user=user).count() == 0
-
-    def test_saved_view_save_get_redirects(self, logged_in_client):
-        """GET request redirects to home."""
-        response = logged_in_client.get(reverse("saved_view_save"))
+    assert response.status_code == 302
+    assert response.url == reverse("backup_manage")
 
+
+def test_backup_import_restores_data(logged_in_client, db):
+    """The backup import view successfully restores data from a backup."""
+    # Create test data and backup
+    original_media = Media.objects.create(title="Original Media", media_type="BOOK", status="COMPLETED")
+
+    with TemporaryDirectory() as tmpdir:
+        # Create a backup
+        backup_path = create_backup(output_dir=Path(tmpdir))
+
+        # Clear the database
+        Media.objects.all().delete()
+        assert Media.objects.count() == 0
+
+        # Import the backup via the view
+        with backup_path.open("rb") as backup_file:
+            uploaded_file = SimpleUploadedFile(backup_path.name, backup_file.read(), content_type="application/x-tar")
+            response = logged_in_client.post(reverse("backup_import"), {"backup_file": uploaded_file})
+
+        # Should redirect to home
         assert response.status_code == 302
         assert response.url == reverse("home")
 
-    def test_saved_view_save_stores_all_filter_types(self, logged_in_client, user, db):
-        """All filter parameters are correctly stored."""
-        from core.models import Agent
-
-        agent = Agent.objects.create(name="Test Author")
-
-        data = {
-            "view_name": "Complex View",
-            "type": ["BOOK", "FILM"],
-            "status": ["COMPLETED", "IN_PROGRESS"],
-            "score": ["8", "9", "10"],
-            "contributor": str(agent.pk),
-            "review_from": "2024-01-01",
-            "review_to": "2024-12-31",
-            "has_review": "filled",
-            "has_cover": "empty",
-            "sort": "score",
-            "view_mode": "list",
-        }
-        response = logged_in_client.post(reverse("saved_view_save"), data)
-
-        assert response.status_code == 302
-
-        saved_view = SavedView.objects.get(user=user, name="Complex View")
-        assert saved_view.filter_types == ["BOOK", "FILM"]
-        assert saved_view.filter_statuses == ["COMPLETED", "IN_PROGRESS"]
-        assert saved_view.filter_scores == ["8", "9", "10"]
-        assert saved_view.filter_contributor_id == agent.pk
-        assert saved_view.filter_review_from == "2024-01-01"
-        assert saved_view.filter_review_to == "2024-12-31"
-        assert saved_view.filter_has_review == "filled"
-        assert saved_view.filter_has_cover == "empty"
-        assert saved_view.sort == "score"
-        assert saved_view.view_mode == "list"
-
-    def test_saved_view_save_redirects_with_filters(self, logged_in_client, user, db):
-        """After saving, redirects to home with all filters applied in URL."""
-        data = {
-            "view_name": "Filtered View",
-            "type": ["BOOK"],
-            "status": ["COMPLETED"],
-            "sort": "-score",
-            "view_mode": "grid",
-        }
-        response = logged_in_client.post(reverse("saved_view_save"), data)
-
-        assert response.status_code == 302
-        # URL should contain the filters
-        assert "type=BOOK" in response.url
-        assert "status=COMPLETED" in response.url
-        assert "sort=-score" in response.url
-        assert "view_mode=grid" in response.url
-
-
-class TestSavedViewDeleteView:
-    """Tests for the saved_view_delete view."""
-
-    def test_saved_view_delete_removes_view(self, logged_in_client, user, db):
-        """POST request deletes the saved view."""
-        saved_view = SavedView.objects.create(user=user, name="To Delete")
-
-        response = logged_in_client.post(reverse("saved_view_delete", kwargs={"pk": saved_view.pk}))
-
-        assert response.status_code == 302
-        assert response.url == reverse("home")
-        assert not SavedView.objects.filter(pk=saved_view.pk).exists()
-
-    def test_saved_view_delete_only_deletes_own_views(self, logged_in_client, user, django_user_model, db):
-        """User cannot delete another user's saved views."""
-        other_user = django_user_model.objects.create_user(
-            username="otheruser",
-            email="other@example.com",
-            password="testpass123",
-        )
-        other_view = SavedView.objects.create(user=other_user, name="Other View")
-
-        response = logged_in_client.post(reverse("saved_view_delete", kwargs={"pk": other_view.pk}))
-
-        # Should redirect but view should still exist
-        assert response.status_code == 302
-        assert SavedView.objects.filter(pk=other_view.pk).exists()
-
-    def test_saved_view_delete_nonexistent_view(self, logged_in_client, db):
-        """Deleting a non-existent view redirects with error message."""
-        response = logged_in_client.post(reverse("saved_view_delete", kwargs={"pk": 99999}))
-
-        assert response.status_code == 302
-        assert response.url == reverse("home")
-
-    def test_saved_view_delete_get_redirects(self, logged_in_client, user, db):
-        """GET request redirects to home without deleting."""
-        saved_view = SavedView.objects.create(user=user, name="To Keep")
-
-        response = logged_in_client.get(reverse("saved_view_delete", kwargs={"pk": saved_view.pk}))
-
-        assert response.status_code == 302
-        assert response.url == reverse("home")
-        assert SavedView.objects.filter(pk=saved_view.pk).exists()
-
-
-class TestSavedViewValidation:
-    """Tests for saved view input validation."""
-
-    def test_saved_view_rejects_invalid_media_type(self, logged_in_client, user, db):
-        """Saved view validation rejects invalid media types."""
-        data = {
-            "view_name": "Invalid Type View",
-            "type": ["INVALID_TYPE"],
-            "sort": "-review_date",
-            "view_mode": "grid",
-        }
-        response = logged_in_client.post(reverse("saved_view_save"), data, follow=True)
-
-        # Should redirect back to home with error
-        assert response.status_code == 200
-        # View should not be created
-        assert not SavedView.objects.filter(user=user, name="Invalid Type View").exists()
-
-    def test_saved_view_rejects_invalid_status(self, logged_in_client, user, db):
-        """Saved view validation rejects invalid statuses."""
-        data = {
-            "view_name": "Invalid Status View",
-            "status": ["INVALID_STATUS"],
-            "sort": "-review_date",
-            "view_mode": "grid",
-        }
-        logged_in_client.post(reverse("saved_view_save"), data)
-
-        # View should not be created
-        assert not SavedView.objects.filter(user=user, name="Invalid Status View").exists()
-
-    def test_saved_view_rejects_invalid_score(self, logged_in_client, user, db):
-        """Saved view validation rejects invalid scores."""
-        data = {
-            "view_name": "Invalid Score View",
-            "score": ["invalid"],
-            "sort": "-review_date",
-            "view_mode": "grid",
-        }
-        logged_in_client.post(reverse("saved_view_save"), data)
-
-        # View should not be created
-        assert not SavedView.objects.filter(user=user, name="Invalid Score View").exists()
-
-    def test_saved_view_rejects_invalid_sort_field(self, logged_in_client, user, db):
-        """Saved view validation rejects invalid sort fields."""
-        data = {
-            "view_name": "Invalid Sort View",
-            "sort": "invalid_field",
-            "view_mode": "grid",
-        }
-        logged_in_client.post(reverse("saved_view_save"), data)
-
-        # View should not be created
-        assert not SavedView.objects.filter(user=user, name="Invalid Sort View").exists()
-
-    def test_saved_view_rejects_invalid_view_mode(self, logged_in_client, user, db):
-        """Saved view validation rejects invalid view modes."""
-        data = {
-            "view_name": "Invalid View Mode",
-            "sort": "-review_date",
-            "view_mode": "invalid_mode",
-        }
-        logged_in_client.post(reverse("saved_view_save"), data)
-
-        # View should not be created
-        assert not SavedView.objects.filter(user=user, name="Invalid View Mode").exists()
-
-    def test_saved_view_rejects_nonexistent_contributor(self, logged_in_client, user, db):
-        """Saved view validation rejects non-existent contributor IDs."""
-        data = {
-            "view_name": "Invalid Contributor View",
-            "contributor": "99999",
-            "sort": "-review_date",
-            "view_mode": "grid",
-        }
-        logged_in_client.post(reverse("saved_view_save"), data)
-
-        # View should not be created
-        assert not SavedView.objects.filter(user=user, name="Invalid Contributor View").exists()
-
-    def test_saved_view_rejects_invalid_contributor_format(self, logged_in_client, user, db):
-        """Saved view validation rejects invalid contributor ID formats."""
-        data = {
-            "view_name": "Invalid Contributor Format",
-            "contributor": "not-a-number",
-            "sort": "-review_date",
-            "view_mode": "grid",
-        }
-        logged_in_client.post(reverse("saved_view_save"), data)
-
-        # View should not be created
-        assert not SavedView.objects.filter(user=user, name="Invalid Contributor Format").exists()
-
-    def test_saved_view_rejects_invalid_date_format(self, logged_in_client, user, db):
-        """Saved view validation rejects invalid date formats."""
-        data = {
-            "view_name": "Invalid Date View",
-            "review_from": "not-a-date",
-            "sort": "-review_date",
-            "view_mode": "grid",
-        }
-        logged_in_client.post(reverse("saved_view_save"), data)
-
-        # View should not be created
-        assert not SavedView.objects.filter(user=user, name="Invalid Date View").exists()
-
-    def test_saved_view_rejects_invalid_has_review_value(self, logged_in_client, user, db):
-        """Saved view validation rejects invalid has_review values."""
-        data = {
-            "view_name": "Invalid Has Review",
-            "has_review": "invalid",
-            "sort": "-review_date",
-            "view_mode": "grid",
-        }
-        logged_in_client.post(reverse("saved_view_save"), data)
-
-        # View should not be created
-        assert not SavedView.objects.filter(user=user, name="Invalid Has Review").exists()
-
-    def test_saved_view_rejects_invalid_has_cover_value(self, logged_in_client, user, db):
-        """Saved view validation rejects invalid has_cover values."""
-        data = {
-            "view_name": "Invalid Has Cover",
-            "has_cover": "invalid",
-            "sort": "-review_date",
-            "view_mode": "grid",
-        }
-        logged_in_client.post(reverse("saved_view_save"), data)
-
-        # View should not be created
-        assert not SavedView.objects.filter(user=user, name="Invalid Has Cover").exists()
-
-    def test_saved_view_accepts_valid_data(self, logged_in_client, user, db):
-        """Saved view validation accepts all valid data."""
-        agent = Agent.objects.create(name="Valid Author")
-
-        data = {
-            "view_name": "Valid View",
-            "type": ["BOOK", "FILM"],
-            "status": ["COMPLETED"],
-            "score": ["8", "9", "none"],
-            "contributor": str(agent.pk),
-            "review_from": "2024-01",
-            "review_to": "2024-12-31",
-            "has_review": "filled",
-            "has_cover": "empty",
-            "sort": "-score",
-            "view_mode": "list",
-        }
-        response = logged_in_client.post(reverse("saved_view_save"), data)
-
-        # Should redirect successfully
-        assert response.status_code == 302
-
-        # View should be created
-        assert SavedView.objects.filter(user=user, name="Valid View").exists()
-        saved_view = SavedView.objects.get(user=user, name="Valid View")
-        assert saved_view.filter_types == ["BOOK", "FILM"]
-        assert saved_view.filter_statuses == ["COMPLETED"]
-        assert saved_view.filter_scores == ["8", "9", "none"]
-        assert saved_view.filter_contributor_id == agent.pk
-        assert saved_view.filter_review_from == "2024-01"
-        assert saved_view.filter_review_to == "2024-12-31"
-        assert saved_view.filter_has_review == "filled"
-        assert saved_view.filter_has_cover == "empty"
-        assert saved_view.sort == "-score"
-        assert saved_view.view_mode == "list"
-
-    def test_saved_view_accepts_descending_sort(self, logged_in_client, user, db):
-        """Saved view validation accepts descending sort fields (with -)."""
-        data = {
-            "view_name": "Descending Sort View",
-            "sort": "-created_at",
-            "view_mode": "grid",
-        }
-        response = logged_in_client.post(reverse("saved_view_save"), data)
-
-        # Should redirect successfully
-        assert response.status_code == 302
-
-        # View should be created with descending sort
-        assert SavedView.objects.filter(user=user, name="Descending Sort View").exists()
-        saved_view = SavedView.objects.get(user=user, name="Descending Sort View")
-        assert saved_view.sort == "-created_at"
-
-
-class TestMediaImportView:
-    """Tests for the media_import view."""
-
-    def test_media_import_accessible_when_logged_in(self, logged_in_client):
-        """The import view is accessible when logged in."""
-        response = logged_in_client.get(reverse("media_import"))
-
-        assert response.status_code == 200
-        assert "base/media_import.html" in [t.name for t in response.templates]
-
-    def test_media_import_default_source_is_tmdb(self, logged_in_client):
-        """Without parameters, default source is TMDB."""
-        response = logged_in_client.get(reverse("media_import"))
-
-        assert response.context["default_source"] == "tmdb"
-        assert response.context["default_query"] == ""
-
-    def test_media_import_film_maps_to_tmdb(self, logged_in_client):
-        """FILM media type maps to TMDB source."""
-        response = logged_in_client.get(
-            reverse("media_import"),
-            {"media_type": "FILM", "title": "The Matrix"},
-        )
-
-        assert response.context["default_source"] == "tmdb"
-        assert response.context["default_query"] == "The Matrix"
-
-    def test_media_import_tv_maps_to_tmdb(self, logged_in_client):
-        """TV media type maps to TMDB source."""
-        response = logged_in_client.get(
-            reverse("media_import"),
-            {"media_type": "TV", "title": "Breaking Bad"},
-        )
-
-        assert response.context["default_source"] == "tmdb"
-        assert response.context["default_query"] == "Breaking Bad"
-
-    def test_media_import_game_maps_to_igdb(self, logged_in_client):
-        """GAME media type maps to IGDB source."""
-        response = logged_in_client.get(
-            reverse("media_import"),
-            {"media_type": "GAME", "title": "The Witcher 3"},
-        )
-
-        assert response.context["default_source"] == "igdb"
-        assert response.context["default_query"] == "The Witcher 3"
-
-    def test_media_import_book_maps_to_openlibrary(self, logged_in_client):
-        """BOOK media type maps to OpenLibrary source."""
-        response = logged_in_client.get(
-            reverse("media_import"),
-            {"media_type": "BOOK", "title": "1984"},
-        )
-
-        assert response.context["default_source"] == "openlibrary"
-        assert response.context["default_query"] == "1984"
-
-    def test_media_import_comic_maps_to_openlibrary(self, logged_in_client):
-        """COMIC media type maps to OpenLibrary source."""
-        response = logged_in_client.get(
-            reverse("media_import"),
-            {"media_type": "COMIC", "title": "Watchmen"},
-        )
-
-        assert response.context["default_source"] == "openlibrary"
-        assert response.context["default_query"] == "Watchmen"
-
-    def test_media_import_music_maps_to_musicbrainz(self, logged_in_client):
-        """MUSIC media type maps to MusicBrainz source."""
-        response = logged_in_client.get(
-            reverse("media_import"),
-            {"media_type": "MUSIC", "title": "Abbey Road"},
-        )
-
-        assert response.context["default_source"] == "musicbrainz"
-        assert response.context["default_query"] == "Abbey Road"
-
-    def test_media_import_unknown_type_defaults_to_tmdb(self, logged_in_client):
-        """Unknown media type defaults to TMDB source."""
-        response = logged_in_client.get(
-            reverse("media_import"),
-            {"media_type": "UNKNOWN", "title": "Something"},
-        )
-
-        assert response.context["default_source"] == "tmdb"
-
-    def test_media_import_passes_media_id(self, logged_in_client, media):
-        """Media ID is passed to the template context."""
-        response = logged_in_client.get(
-            reverse("media_import"),
-            {"media_id": media.pk},
-        )
-
-        assert response.context["media_id"] == str(media.pk)
-
-    def test_media_import_handles_special_characters_in_title(self, logged_in_client):
-        """Title with special characters is handled correctly."""
-        response = logged_in_client.get(
-            reverse("media_import"),
-            {"media_type": "FILM", "title": "Amélie & Co: L'histoire"},
-        )
-
-        assert response.context["default_query"] == "Amélie & Co: L'histoire"
+        # Data should be restored
+        assert Media.objects.count() == 1
+        restored_media = Media.objects.first()
+        assert restored_media.title == original_media.title
+        assert restored_media.status == original_media.status
+
+
+def test_backup_import_handles_errors(logged_in_client):
+    """The backup import view handles errors gracefully."""
+    # Create a valid tar.gz file with invalid content
+    invalid_file = SimpleUploadedFile("backup.tar.gz", b"invalid content", content_type="application/x-tar")
+
+    response = logged_in_client.post(reverse("backup_import"), {"backup_file": invalid_file})
+
+    # Should redirect back to backup manage with error message
+    assert response.status_code == 302
+    assert response.url == reverse("backup_manage")
+
+
+def test_index_paginates_results_across_pages(logged_in_client, media_factory):
+    """Index view paginates results with 20 items per page and navigates correctly."""
+    # Create 25 media items
+    for i in range(25):
+        media_factory(title=f"Media {i}")
+
+    # Test first page
+    response_page1 = logged_in_client.get(reverse("home"))
+    assert response_page1.status_code == 200
+    assert "page_obj" in response_page1.context
+    assert len(response_page1.context["media_list"]) == 20
+    assert response_page1.context["page_obj"].has_next()
+
+    # Test second page
+    response_page2 = logged_in_client.get(reverse("home"), {"page": 2})
+    assert response_page2.status_code == 200
+    assert len(response_page2.context["media_list"]) == 5
+    assert response_page2.context["page_obj"].has_previous()
+    assert not response_page2.context["page_obj"].has_next()
+
+
+def test_search_paginates_results(logged_in_client, media_factory):
+    """Search view paginates results."""
+    # Create 25 media items with searchable title
+    for i in range(25):
+        media_factory(title=f"Searchable {i}")
+
+    response = logged_in_client.get(reverse("home"), {"search": "Searchable"})
+
+    assert response.status_code == 200
+    assert len(response.context["media_list"]) == 20
+    assert response.context["page_obj"].has_next()
+
+
+def test_load_more_returns_partial_template(logged_in_client, media_factory):
+    """Load more view returns the media-items-page partial template."""
+    for i in range(25):
+        media_factory(title=f"Media {i}")
+
+    response = logged_in_client.get(reverse("load_more_media"), {"page": 2})
+
+    assert response.status_code == 200
+    assert "partials/media_items/media_list_page.html" in [t.name for t in response.templates]
+
+
+def test_load_more_returns_next_page_items(logged_in_client, media_factory):
+    """Load more view returns items for the requested page."""
+    # Create 25 items
+    for i in range(25):
+        media_factory(title=f"Media {i:02d}")
+
+    # Request page 2 (items 21-25)
+    response = logged_in_client.get(reverse("load_more_media"), {"page": 2})
+
+    assert response.status_code == 200
+    assert len(response.context["media_list"]) == 5
+
+
+def test_load_more_preserves_sorting(logged_in_client, media_factory):
+    """Load more view preserves sort order from initial request."""
+    media_factory(title="A", score=5)
+    media_factory(title="B", score=8)
+    media_factory(title="C", score=3)
+
+    response = logged_in_client.get(reverse("load_more_media"), {"page": 1, "sort": "score"})
+
+    assert response.status_code == 200
+    scores = [m.score for m in response.context["media_list"] if m.score is not None]
+    # Should be sorted ascending by score
+    assert scores == sorted(scores)
+
+
+def test_load_more_preserves_filters(logged_in_client, media_factory):
+    """Load more view preserves filters from initial request."""
+    media_factory(title="Book 1", media_type="BOOK")
+    media_factory(title="Film 1", media_type="FILM")
+    media_factory(title="Book 2", media_type="BOOK")
+
+    response = logged_in_client.get(reverse("load_more_media"), {"page": 1, "type": "BOOK"})
+
+    assert response.status_code == 200
+    media_types = [m.media_type for m in response.context["media_list"]]
+    assert all(mt == "BOOK" for mt in media_types)
+
+
+def test_load_more_with_search_query(logged_in_client, media_factory):
+    """Load more view applies search query when provided."""
+    media_factory(title="Python Guide")
+    media_factory(title="JavaScript Guide")
+    media_factory(title="Python Cookbook")
+
+    response = logged_in_client.get(reverse("load_more_media"), {"page": 1, "search": "Python"})
+
+    assert response.status_code == 200
+    assert len(response.context["media_list"]) == 2
+    titles = [m.title for m in response.context["media_list"]]
+    assert all("Python" in title for title in titles)
+
+
+def test_load_more_page_obj_pagination_state(logged_in_client, media_factory):
+    """Load more view sets has_next correctly across different page states."""
+    # Create 45 items (3 pages of 20 items each)
+    for i in range(45):
+        media_factory(title=f"Media {i}")
+
+    # Test page 2 (middle page) - should have next
+    response_page2 = logged_in_client.get(reverse("load_more_media"), {"page": 2})
+    assert response_page2.status_code == 200
+    assert response_page2.context["page_obj"].has_next()
+    assert response_page2.context["page_obj"].number == 2
+
+    # Test page 3 (last page) - should not have next
+    response_page3 = logged_in_client.get(reverse("load_more_media"), {"page": 3})
+    assert response_page3.status_code == 200
+    assert not response_page3.context["page_obj"].has_next()
+    assert response_page3.context["page_obj"].number == 3
+
+
+def test_load_more_includes_view_mode_in_context(logged_in_client, media_factory):
+    """Load more view includes view_mode in context for template rendering."""
+    media_factory(title="Test")
+
+    response_default = logged_in_client.get(reverse("load_more_media"), {"page": 1})
+    response_list = logged_in_client.get(reverse("load_more_media"), {"page": 1, "view_mode": "list"})
+    response_grid = logged_in_client.get(reverse("load_more_media"), {"page": 1, "view_mode": "grid"})
+
+    assert response_default.context["view_mode"] == "grid"
+    assert response_list.context["view_mode"] == "list"
+    assert response_grid.context["view_mode"] == "grid"
+
+
+def test_media_detail_accessible_when_logged_in(logged_in_client, media):
+    """The detail view is accessible when logged in."""
+    response = logged_in_client.get(reverse("media_detail", kwargs={"pk": media.pk}))
+
+    assert response.status_code == 200
+    assert response.context["media"] == media
+
+
+def test_media_detail_displays_correct_template(logged_in_client, media):
+    """The detail view uses the media_detail template."""
+    response = logged_in_client.get(reverse("media_detail", kwargs={"pk": media.pk}))
+
+    assert response.status_code == 200
+    assert "base/media_detail.html" in [t.name for t in response.templates]
+
+
+def test_media_detail_nonexistent_returns_404(logged_in_client):
+    """Accessing detail view with nonexistent media returns 404."""
+    response = logged_in_client.get(reverse("media_detail", kwargs={"pk": 99999}))
+
+    assert response.status_code == 404
+
+
+def test_media_detail_shows_all_fields(logged_in_client, db):
+    """The detail view displays all media fields."""
+    agent = Agent.objects.create(name="Test Author")
+    media = Media.objects.create(
+        title="Complete Media",
+        media_type="BOOK",
+        status="COMPLETED",
+        score=8,
+        review="This is a detailed review.",
+        pub_year=2023,
+        external_uri="https://example.com",
+    )
+    media.contributors.add(agent)
+
+    response = logged_in_client.get(reverse("media_detail", kwargs={"pk": media.pk}))
+    content = response.content.decode("utf-8")
+
+    assert media.title in content
+    assert "2023" in content
+    assert agent.name in content
+    assert "https://example.com" in content
+
+
+def test_media_detail_contributor_links_to_filtered_list(logged_in_client, db):
+    """Contributor links in detail view navigate to filtered home page."""
+    agent = Agent.objects.create(name="Test Contributor")
+    media = Media.objects.create(
+        title="Test Media",
+        media_type="BOOK",
+    )
+    media.contributors.add(agent)
+
+    response = logged_in_client.get(reverse("media_detail", kwargs={"pk": media.pk}))
+    content = response.content.decode("utf-8")
+
+    # Should contain a link to home with contributor filter
+    assert f"contributor={agent.id}" in content
+    assert 'class="link link-hover contributor-link"' in content
+    # Should NOT contain HTMX attributes for contributor links
+    assert "hx-target" not in content
+
+
+def test_saved_view_save_creates_new_view(logged_in_client, user, db):
+    """POST with valid data creates a new saved view."""
+    data = {
+        "view_name": "My Books",
+        "type": ["BOOK"],
+        "status": ["COMPLETED"],
+        "score": ["8", "9"],
+        "sort": "-score",
+        "view_mode": "list",
+    }
+    response = logged_in_client.post(reverse("saved_view_save"), data)
+
+    # Should redirect to home with filters applied
+    assert response.status_code == 302
+    assert "/" in response.url
+
+    # View should be created in database
+    assert SavedView.objects.filter(user=user, name="My Books").exists()
+    saved_view = SavedView.objects.get(user=user, name="My Books")
+    assert saved_view.filter_types == ["BOOK"]
+    assert saved_view.filter_statuses == ["COMPLETED"]
+    assert saved_view.filter_scores == ["8", "9"]
+    assert saved_view.sort == "-score"
+    assert saved_view.view_mode == "list"
+
+
+def test_saved_view_save_updates_existing_view(logged_in_client, user, db):
+    """POST with existing view name updates the view instead of creating duplicate."""
+    # Create initial view
+    SavedView.objects.create(
+        user=user,
+        name="My View",
+        filter_types=["BOOK"],
+        sort="-review_date",
+    )
+
+    # Update with different filters
+    data = {
+        "view_name": "My View",
+        "type": ["FILM"],
+        "sort": "-score",
+        "view_mode": "grid",
+    }
+    response = logged_in_client.post(reverse("saved_view_save"), data)
+
+    assert response.status_code == 302
+
+    # Should still be only one view with that name
+    assert SavedView.objects.filter(user=user, name="My View").count() == 1
+
+    # View should be updated
+    saved_view = SavedView.objects.get(user=user, name="My View")
+    assert saved_view.filter_types == ["FILM"]
+    assert saved_view.sort == "-score"
+    assert saved_view.view_mode == "grid"
+
+
+def test_saved_view_save_requires_view_name(logged_in_client, user, db):
+    """POST without view_name redirects with error message."""
+    data = {
+        "type": ["BOOK"],
+    }
+    response = logged_in_client.post(reverse("saved_view_save"), data)
+
+    # Should redirect back to home
+    assert response.status_code == 302
+
+    # No view should be created
+    assert SavedView.objects.filter(user=user).count() == 0
+
+
+def test_saved_view_save_get_redirects(logged_in_client):
+    """GET request redirects to home."""
+    response = logged_in_client.get(reverse("saved_view_save"))
+
+    assert response.status_code == 302
+    assert response.url == reverse("home")
+
+
+def test_saved_view_save_stores_all_filter_types(logged_in_client, user, db):
+    """All filter parameters are correctly stored."""
+    from core.models import Agent
+
+    agent = Agent.objects.create(name="Test Author")
+
+    data = {
+        "view_name": "Complex View",
+        "type": ["BOOK", "FILM"],
+        "status": ["COMPLETED", "IN_PROGRESS"],
+        "score": ["8", "9", "10"],
+        "contributor": str(agent.pk),
+        "review_from": "2024-01-01",
+        "review_to": "2024-12-31",
+        "has_review": "filled",
+        "has_cover": "empty",
+        "sort": "score",
+        "view_mode": "list",
+    }
+    response = logged_in_client.post(reverse("saved_view_save"), data)
+
+    assert response.status_code == 302
+
+    saved_view = SavedView.objects.get(user=user, name="Complex View")
+    assert saved_view.filter_types == ["BOOK", "FILM"]
+    assert saved_view.filter_statuses == ["COMPLETED", "IN_PROGRESS"]
+    assert saved_view.filter_scores == ["8", "9", "10"]
+    assert saved_view.filter_contributor_id == agent.pk
+    assert saved_view.filter_review_from == "2024-01-01"
+    assert saved_view.filter_review_to == "2024-12-31"
+    assert saved_view.filter_has_review == "filled"
+    assert saved_view.filter_has_cover == "empty"
+    assert saved_view.sort == "score"
+    assert saved_view.view_mode == "list"
+
+
+def test_saved_view_save_redirects_with_filters(logged_in_client, user, db):
+    """After saving, redirects to home with all filters applied in URL."""
+    data = {
+        "view_name": "Filtered View",
+        "type": ["BOOK"],
+        "status": ["COMPLETED"],
+        "sort": "-score",
+        "view_mode": "grid",
+    }
+    response = logged_in_client.post(reverse("saved_view_save"), data)
+
+    assert response.status_code == 302
+    # URL should contain the filters
+    assert "type=BOOK" in response.url
+    assert "status=COMPLETED" in response.url
+    assert "sort=-score" in response.url
+    assert "view_mode=grid" in response.url
+
+
+def test_saved_view_delete_removes_view(logged_in_client, user, db):
+    """POST request deletes the saved view."""
+    saved_view = SavedView.objects.create(user=user, name="To Delete")
+
+    response = logged_in_client.post(reverse("saved_view_delete", kwargs={"pk": saved_view.pk}))
+
+    assert response.status_code == 302
+    assert response.url == reverse("home")
+    assert not SavedView.objects.filter(pk=saved_view.pk).exists()
+
+
+def test_saved_view_delete_only_deletes_own_views(logged_in_client, user, django_user_model, db):
+    """User cannot delete another user's saved views."""
+    other_user = django_user_model.objects.create_user(
+        username="otheruser",
+        email="other@example.com",
+        password="testpass123",
+    )
+    other_view = SavedView.objects.create(user=other_user, name="Other View")
+
+    response = logged_in_client.post(reverse("saved_view_delete", kwargs={"pk": other_view.pk}))
+
+    # Should redirect but view should still exist
+    assert response.status_code == 302
+    assert SavedView.objects.filter(pk=other_view.pk).exists()
+
+
+def test_saved_view_delete_nonexistent_view(logged_in_client, db):
+    """Deleting a non-existent view redirects with error message."""
+    response = logged_in_client.post(reverse("saved_view_delete", kwargs={"pk": 99999}))
+
+    assert response.status_code == 302
+    assert response.url == reverse("home")
+
+
+def test_saved_view_delete_get_redirects(logged_in_client, user, db):
+    """GET request redirects to home without deleting."""
+    saved_view = SavedView.objects.create(user=user, name="To Keep")
+
+    response = logged_in_client.get(reverse("saved_view_delete", kwargs={"pk": saved_view.pk}))
+
+    assert response.status_code == 302
+    assert response.url == reverse("home")
+    assert SavedView.objects.filter(pk=saved_view.pk).exists()
+
+
+def test_saved_view_rejects_invalid_media_type(logged_in_client, user, db):
+    """Saved view validation rejects invalid media types."""
+    data = {
+        "view_name": "Invalid Type View",
+        "type": ["INVALID_TYPE"],
+        "sort": "-review_date",
+        "view_mode": "grid",
+    }
+    response = logged_in_client.post(reverse("saved_view_save"), data, follow=True)
+
+    # Should redirect back to home with error
+    assert response.status_code == 200
+    # View should not be created
+    assert not SavedView.objects.filter(user=user, name="Invalid Type View").exists()
+
+
+def test_saved_view_rejects_invalid_status(logged_in_client, user, db):
+    """Saved view validation rejects invalid statuses."""
+    data = {
+        "view_name": "Invalid Status View",
+        "status": ["INVALID_STATUS"],
+        "sort": "-review_date",
+        "view_mode": "grid",
+    }
+    logged_in_client.post(reverse("saved_view_save"), data)
+
+    # View should not be created
+    assert not SavedView.objects.filter(user=user, name="Invalid Status View").exists()
+
+
+def test_saved_view_rejects_invalid_score(logged_in_client, user, db):
+    """Saved view validation rejects invalid scores."""
+    data = {
+        "view_name": "Invalid Score View",
+        "score": ["invalid"],
+        "sort": "-review_date",
+        "view_mode": "grid",
+    }
+    logged_in_client.post(reverse("saved_view_save"), data)
+
+    # View should not be created
+    assert not SavedView.objects.filter(user=user, name="Invalid Score View").exists()
+
+
+def test_saved_view_rejects_invalid_sort_field(logged_in_client, user, db):
+    """Saved view validation rejects invalid sort fields."""
+    data = {
+        "view_name": "Invalid Sort View",
+        "sort": "invalid_field",
+        "view_mode": "grid",
+    }
+    logged_in_client.post(reverse("saved_view_save"), data)
+
+    # View should not be created
+    assert not SavedView.objects.filter(user=user, name="Invalid Sort View").exists()
+
+
+def test_saved_view_rejects_invalid_view_mode(logged_in_client, user, db):
+    """Saved view validation rejects invalid view modes."""
+    data = {
+        "view_name": "Invalid View Mode",
+        "sort": "-review_date",
+        "view_mode": "invalid_mode",
+    }
+    logged_in_client.post(reverse("saved_view_save"), data)
+
+    # View should not be created
+    assert not SavedView.objects.filter(user=user, name="Invalid View Mode").exists()
+
+
+def test_saved_view_rejects_nonexistent_contributor(logged_in_client, user, db):
+    """Saved view validation rejects non-existent contributor IDs."""
+    data = {
+        "view_name": "Invalid Contributor View",
+        "contributor": "99999",
+        "sort": "-review_date",
+        "view_mode": "grid",
+    }
+    logged_in_client.post(reverse("saved_view_save"), data)
+
+    # View should not be created
+    assert not SavedView.objects.filter(user=user, name="Invalid Contributor View").exists()
+
+
+def test_saved_view_rejects_invalid_contributor_format(logged_in_client, user, db):
+    """Saved view validation rejects invalid contributor ID formats."""
+    data = {
+        "view_name": "Invalid Contributor Format",
+        "contributor": "not-a-number",
+        "sort": "-review_date",
+        "view_mode": "grid",
+    }
+    logged_in_client.post(reverse("saved_view_save"), data)
+
+    # View should not be created
+    assert not SavedView.objects.filter(user=user, name="Invalid Contributor Format").exists()
+
+
+def test_saved_view_rejects_invalid_date_format(logged_in_client, user, db):
+    """Saved view validation rejects invalid date formats."""
+    data = {
+        "view_name": "Invalid Date View",
+        "review_from": "not-a-date",
+        "sort": "-review_date",
+        "view_mode": "grid",
+    }
+    logged_in_client.post(reverse("saved_view_save"), data)
+
+    # View should not be created
+    assert not SavedView.objects.filter(user=user, name="Invalid Date View").exists()
+
+
+def test_saved_view_rejects_invalid_has_review_value(logged_in_client, user, db):
+    """Saved view validation rejects invalid has_review values."""
+    data = {
+        "view_name": "Invalid Has Review",
+        "has_review": "invalid",
+        "sort": "-review_date",
+        "view_mode": "grid",
+    }
+    logged_in_client.post(reverse("saved_view_save"), data)
+
+    # View should not be created
+    assert not SavedView.objects.filter(user=user, name="Invalid Has Review").exists()
+
+
+def test_saved_view_rejects_invalid_has_cover_value(logged_in_client, user, db):
+    """Saved view validation rejects invalid has_cover values."""
+    data = {
+        "view_name": "Invalid Has Cover",
+        "has_cover": "invalid",
+        "sort": "-review_date",
+        "view_mode": "grid",
+    }
+    logged_in_client.post(reverse("saved_view_save"), data)
+
+    # View should not be created
+    assert not SavedView.objects.filter(user=user, name="Invalid Has Cover").exists()
+
+
+def test_saved_view_accepts_valid_data(logged_in_client, user, db):
+    """Saved view validation accepts all valid data."""
+    agent = Agent.objects.create(name="Valid Author")
+
+    data = {
+        "view_name": "Valid View",
+        "type": ["BOOK", "FILM"],
+        "status": ["COMPLETED"],
+        "score": ["8", "9", "none"],
+        "contributor": str(agent.pk),
+        "review_from": "2024-01",
+        "review_to": "2024-12-31",
+        "has_review": "filled",
+        "has_cover": "empty",
+        "sort": "-score",
+        "view_mode": "list",
+    }
+    response = logged_in_client.post(reverse("saved_view_save"), data)
+
+    # Should redirect successfully
+    assert response.status_code == 302
+
+    # View should be created
+    assert SavedView.objects.filter(user=user, name="Valid View").exists()
+    saved_view = SavedView.objects.get(user=user, name="Valid View")
+    assert saved_view.filter_types == ["BOOK", "FILM"]
+    assert saved_view.filter_statuses == ["COMPLETED"]
+    assert saved_view.filter_scores == ["8", "9", "none"]
+    assert saved_view.filter_contributor_id == agent.pk
+    assert saved_view.filter_review_from == "2024-01"
+    assert saved_view.filter_review_to == "2024-12-31"
+    assert saved_view.filter_has_review == "filled"
+    assert saved_view.filter_has_cover == "empty"
+    assert saved_view.sort == "-score"
+    assert saved_view.view_mode == "list"


### PR DESCRIPTION
Test classes provided no value: no shared state, no shared logic, no inheritance. Standalone pytest functions are sufficient and reduce syntactic noise (no self, no class declarations).